### PR TITLE
Implements the `set_turbo_frame_src` operation

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7,6 +7,7 @@ import * as Debug from "./actions/debug"
 import * as Events from "./actions/events"
 import * as History from "./actions/history"
 import * as Storage from "./actions/storage"
+import * as TurboFrames from "./actions/turbo_frames"
 
 export * from "./actions/attributes"
 export * from "./actions/browser"
@@ -15,6 +16,7 @@ export * from "./actions/dom"
 export * from "./actions/events"
 export * from "./actions/history"
 export * from "./actions/storage"
+export * from "./actions/turbo_frames"
 
 export function register(streamActions: TurboStreamActions) {
   Attributes.registerAttributesActions(streamActions)
@@ -24,4 +26,5 @@ export function register(streamActions: TurboStreamActions) {
   Events.registerEventsActions(streamActions)
   History.registerHistoryActions(streamActions)
   Storage.registerStorageActions(streamActions)
+  TurboFrames.registerTurboFramesActions(streamActions)
 }

--- a/src/actions/turbo_frames.ts
+++ b/src/actions/turbo_frames.ts
@@ -1,0 +1,22 @@
+import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+
+// turbo_stream.set_turbo_frame_src(frame_id, src)
+export function set_turbo_frame_src(this: StreamElement) {
+  const frameId = this.getAttribute("frame_id") || ""
+  const srcAttribute = this.getAttribute("src") || ""
+  const frame = document.getElementById(frameId)
+
+  if (frame && srcAttribute) {
+    frame.setAttribute("src", srcAttribute)
+  } else if (frame) {
+    console.error(`[TurboPower] no "src" provided for Turbo Streams operation "set_turbo_frame_src"`)
+  } else {
+    console.error(
+      `[TurboPower] couldn't find a TurboFrame with the ID: "${frameId}", for Turbo Streams operation "set_turbo_frame_src"`
+    )
+  }
+}
+
+export function registerTurboFramesActions(streamActions: TurboStreamActions) {
+  streamActions.set_turbo_frame_src = set_turbo_frame_src
+}

--- a/test/turbo_frames/set_turbo_frame_src.test.js
+++ b/test/turbo_frames/set_turbo_frame_src.test.js
@@ -1,0 +1,53 @@
+import sinon from 'sinon'
+import { html, fixture, assert } from '@open-wc/testing'
+import { executeStream, registerAction } from '../test_helpers'
+
+registerAction('set_turbo_frame_src')
+
+describe('set_turbo_frame_src', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  context('errors', () => {
+    it('should print error if no src were provided', async () => {
+      sinon.replace(console, 'error', sinon.fake())
+      await fixture('<turbo-frame id="example-id"></turbo-frame>')
+
+      const expectedError = `[TurboPower] no "src" provided for Turbo Streams operation "set_turbo_frame_src"`
+
+      assert(!console.error.calledWith(expectedError), `console.error wasn't called with "${expectedError}"`)
+
+      await executeStream('<turbo-stream action="set_turbo_frame_src" frame_id="example-id" src=""></turbo-stream>')
+
+      assert(console.error.calledWith(expectedError), `console.error wasn't called with "${expectedError}"`)
+
+    })
+
+    it('should print error if no TurboFrame could be found', async () => {
+      sinon.replace(console, 'error', sinon.fake())
+      await fixture('<turbo-frame id="example-id"></turbo-frame>')
+
+      const expectedError = `[TurboPower] couldn't find a TurboFrame with the ID: "non-existing-frame", for Turbo Streams operation "set_turbo_frame_src"`
+
+      assert(!console.error.calledWith(expectedError), `console.error wasn't called with "${expectedError}"`)
+
+      await executeStream('<turbo-stream action="set_turbo_frame_src" frame_id="non-existing-frame" src="/"></turbo-stream>')
+
+      assert(console.error.calledWith(expectedError), `console.error wasn't called with "${expectedError}"`)
+
+    })
+  })
+
+  context('set src attribute', () => {
+    it('should set src attribute with value', async () => {
+      await fixture('<turbo-frame id="example-id"></turbo-frame>')
+
+      assert.equal(document.querySelector('#example-id').getAttribute('src'), null)
+
+      await executeStream('<turbo-stream action="set_turbo_frame_src" frame_id="example-id" src="/"></turbo-stream>')
+
+      assert.equal(document.querySelector('#example-id').getAttribute('src'), '/')
+    })
+  })
+})


### PR DESCRIPTION
closes #6

This PR adds the `set_turbo_frame_src` operation.  
I created a new `src/actions/turbo_frames.ts` file for turbo_frame operations. 
The reason for this is that in the future there might be more custom TurboFrame operations and it would be nice to have them all in one place.

Another way would have been to implement the `set_turbo_frame_src` operation in existing files like `src/actions/dom.ts` or `src/actions/attributes.ts`. 

Would love to hear what you think about it
