### PR TITLE
Remove `Turbolinks` from the `redirect_to` action

### DIFF
--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -1,16 +1,10 @@
 import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 import * as Turbo from "@hotwired/turbo"
 import { Action } from "@hotwired/turbo/dist/types/core/types"
-import { VisitOptions } from "@hotwired/turbo/dist/types/core/drive/visit"
-
-type Visitable = {
-  visit(location: URL | string, options?: Partial<VisitOptions>): void
-}
 
 declare global {
   interface Window {
     Turbo: typeof Turbo
-    Turbolinks: Visitable
   }
 }
 
@@ -19,10 +13,8 @@ export function redirect_to(this: StreamElement) {
   const turboAction = (this.getAttribute("turbo_action") || "advance") as Action
   const turbo = this.getAttribute("turbo") === "true"
 
-  if (turbo) {
-    if (window.Turbo) window.Turbo.visit(url, { action: turboAction })
-    if (window.Turbolinks) window.Turbolinks.visit(url, { action: turboAction })
-    if (!window.Turbo && !window.Turbolinks) window.location.href = url
+  if (turbo && window.Turbo) {
+    window.Turbo.visit(url, { action: turboAction })
   } else {
     window.location.href = url
   }


### PR DESCRIPTION
closes #16 

Since you need to have Turbo installed in your app to use TurboPower, we don't need to support TurboLinks.