### PR TITLE
Add `typecast` util function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,5 +22,5 @@ export default {
   initialize,
   register,
   Actions,
-  Utils
+  Utils,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,10 @@ import { TurboStreamAction, TurboStreamActions } from "@hotwired/turbo"
 import TurboReady from "turbo_ready"
 import * as TurboMorph from "turbo-morph"
 import * as Actions from "./actions"
+import * as Utils from "./utils"
+
+export * as Actions from "./actions"
+export * as Utils from "./utils"
 
 export function initialize(streamActions: TurboStreamActions) {
   TurboMorph.initialize(streamActions)
@@ -18,4 +22,5 @@ export default {
   initialize,
   register,
   Actions,
+  Utils
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,3 +13,11 @@ export function dasherize(value: string) {
 export function tokenize(value: string) {
   return value.match(/[^\s]+/g) || []
 }
+
+export function typecast(value: string) {
+  try {
+    return JSON.parse(value)
+  } catch (e) {
+    return value
+  }
+}

--- a/test/utils/typecast.test.js
+++ b/test/utils/typecast.test.js
@@ -1,0 +1,51 @@
+import { assert } from '@open-wc/testing'
+import { Utils } from '../../'
+const { typecast } = Utils
+
+describe('utils.typecast', () => {
+  context('Number', () => {
+    it('casts integer value', () => {
+      assert.equal(typecast("123"), 123)
+    })
+
+    it('casts float value', () => {
+      assert.equal(typecast("123.123"), 123.123)
+    })
+  })
+
+  context('String', () => {
+    it('casts string', () => {
+      assert.equal(typecast('"Hello World"'), "Hello World")
+    })
+  })
+
+  context('Boolean', () => {
+    it('casts true', () => {
+      assert.equal(typecast("true"), true)
+    })
+
+    it('casts false', () => {
+      assert.equal(typecast("false"), false)
+    })
+  })
+
+  context('Object', () => {
+    it('casts', () => {
+      assert.deepEqual(typecast('{ "name": "John Doe", "age": 42, "alive": true }'), { name: "John Doe", age: 42, alive: true })
+    })
+  })
+
+  context('Array', () => {
+    it('casts', () => {
+      assert.deepEqual(typecast("[1, 2, 3, 4]"), [1, 2, 3, 4])
+    })
+  })
+
+  context('catch', () => {
+    it('defaults to string value on error', () => {
+      assert.equal(typecast('Hello World'), 'Hello World')
+      assert.equal(typecast('{ abc: 123 }'), '{ abc: 123 }')
+      assert.equal(typecast('[foo, bar, baz]'), '[foo, bar, baz]')
+    })
+  })
+})


### PR DESCRIPTION
This Pull Request adds a `typecast` util function in order to convert any string value to its typecast representation. 

Due to the fact that HTML attributes are always strings we have to do the conversion.