### PR TITLE
Deprecate `invoke` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## Getting Started
 
-`turbo_power` is a power-pack for Turbo Streams. It provides Turbo Streams with a bunch of new actions and additionally adds the `morph` action from [`turbo-morph`](https://github.com/marcoroth/turbo-morph) and the `invoke` action from [`turbo_ready`](https://github.com/hopsoft/turbo_ready).
+`turbo_power` is a power-pack for Turbo Streams. It provides Turbo Streams with a bunch of new actions and additionally adds the `morph` action from [`turbo-morph`](https://github.com/marcoroth/turbo-morph).
 
 **Note:** Requires Turbo **7.2+**
 
@@ -49,17 +49,10 @@ Checkout the instructions in the [`turbo_power-rails`](https://github.com/marcor
 
 ## Custom Actions
 
-### Actions from `turbo_ready`
-
-* [`turbo_stream.invoke(method, *args, selector: nil, camelize: true, id: nil)`](https://github.com/hopsoft/turbo_ready)
-
-### Actions from `turbo-morph`
-
-* [`turbo_stream.morph(target, html = nil, **attributes, &block)`](https://github.com/marcoroth/turbo-morph)
-
 ### DOM Actions
 
 * `turbo_stream.graft(target, parent, **attributes)`
+* [`turbo_stream.morph(target, html = nil, **attributes, &block)`](https://github.com/marcoroth/turbo-morph)
 * `turbo_stream.inner_html(target, html = nil, **attributes, &block)`
 * `turbo_stream.insert_adjacent_html(target, html = nil, position: 'beforeend', **attributes, &block)`
 * `turbo_stream.insert_adjacent_text(target, text, position: 'beforebegin', **attributes)`
@@ -152,8 +145,6 @@ yarn test
 ## Acknowledgments
 
 `turbo_power` is [MIT-licensed](LICENSE) open-source software from [Marco Roth](https://github.com/marcoroth).
-
-`turbo_ready` is [MIT-licensed](https://github.com/hopsoft/turbo_ready/blob/main/MIT-LICENSE) open-source software from [Nate Hopkins](https://github.com/hopsoft).
 
 `turbo-morph` is [MIT-licensed](https://github.com/marcoroth/turbo-morph/blob/master/LICENSE) open-source software from [Marco Roth](https://github.com/marcoroth).
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@hotwired/turbo": ">= 7.2"
   },
   "dependencies": {
-    "turbo-morph": "^0.1.0",
-    "turbo_ready": "^0.1.0"
+    "turbo-morph": "^0.1.0"
   }
 }

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@alpinejs/morph@>=3.10.4":
-  version "3.10.4"
-  resolved "https://registry.yarnpkg.com/@alpinejs/morph/-/morph-3.10.4.tgz#b6f74929c9ab7dbab66a870da7d604dae3029e24"
-  integrity sha512-FXVHYXW8LGHbhrUYy6kQd3JBMl4s5WS0bjMKGbboDfcqfqGHmOY/fCAJIRUCoFDPiBvOlSfxkEQirkmR2VWYAA==
-
 "@hotwired/turbo@^7.2.4":
   version "7.2.4"
   resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.2.4.tgz#0d35541be32cfae3b4f78c6ab9138f5b21f28a21"
@@ -75,25 +70,6 @@
   integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
   dependencies:
     "@types/node" "*"
-
-"@vue/reactivity@~3.1.1":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.1.5.tgz#dbec4d9557f7c8f25c2635db1e23a78a729eb991"
-  integrity sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==
-  dependencies:
-    "@vue/shared" "3.1.5"
-
-"@vue/shared@3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.1.5.tgz#74ee3aad995d0a3996a6bb9533d4d280514ede03"
-  integrity sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==
-
-alpinejs@>=3.10.4:
-  version "3.10.4"
-  resolved "https://registry.yarnpkg.com/alpinejs/-/alpinejs-3.10.4.tgz#61bbadb2275796f545c4f53743f0bcbefa4661d0"
-  integrity sha512-AC6Xchlb/xURO7F93OSMItooClpzGNZRM5+rDa6/3Y20mPxQs1TQ/wfiwiH4mtcVt8yTxdkOW5dOl8CBCK095A==
-  dependencies:
-    "@vue/reactivity" "~3.1.1"
 
 ansi-styles@^4.1.0:
   version "4.3.0"
@@ -615,14 +591,6 @@ turbo-morph@^0.1.0:
 "turbo_power@link:..":
   version "0.0.0"
   uid ""
-
-turbo_ready@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/turbo_ready/-/turbo_ready-0.1.2.tgz#0aa812c0661073106e6efea2f1af41d7b6786e44"
-  integrity sha512-CwJJ2sz72cuNBQuECH2K3H8R9Zb8d3jppK61+i+PwMxPXM8dyL3Rj4K23JPR5RnUBQGIPwxmAVdmPXQxQJoYCA==
-  dependencies:
-    "@alpinejs/morph" ">=3.10.4"
-    alpinejs ">=3.10.4"
 
 unpipe@~1.0.0:
   version "1.0.0"

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -4,6 +4,7 @@ import * as Attributes from "./actions/attributes"
 import * as Browser from "./actions/browser"
 import * as DOM from "./actions/dom"
 import * as Debug from "./actions/debug"
+import * as Deprecated from "./actions/deprecated"
 import * as Events from "./actions/events"
 import * as History from "./actions/history"
 import * as Storage from "./actions/storage"
@@ -13,6 +14,7 @@ import * as Turbo from "./actions/turbo"
 export * from "./actions/attributes"
 export * from "./actions/browser"
 export * from "./actions/debug"
+export * from "./actions/deprecated"
 export * from "./actions/dom"
 export * from "./actions/events"
 export * from "./actions/history"
@@ -24,6 +26,7 @@ export function register(streamActions: TurboStreamActions) {
   Attributes.registerAttributesActions(streamActions)
   Browser.registerBrowserActions(streamActions)
   Debug.registerDebugActions(streamActions)
+  Deprecated.registerDeprecatedActions(streamActions)
   DOM.registerDOMActions(streamActions)
   Events.registerEventsActions(streamActions)
   History.registerHistoryActions(streamActions)

--- a/src/actions/deprecated.ts
+++ b/src/actions/deprecated.ts
@@ -1,0 +1,13 @@
+import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+
+export function invoke(this: StreamElement) {
+  console.warn(
+    "[TurboPower] The `invoke` Turbo Stream Action was removed from TurboPower. If you'd like to continue using this action please use the successor library instead. Read more here: https://github.com/hopsoft/turbo_boost-streams"
+  )
+}
+
+export function registerDeprecatedActions(streamActions: TurboStreamActions) {
+  if (!streamActions.invoke) {
+    streamActions.invoke = invoke
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,10 @@
 import { TurboStreamAction, TurboStreamActions } from "@hotwired/turbo"
 
-import TurboReady from "turbo_ready"
 import * as TurboMorph from "turbo-morph"
 import * as Actions from "./actions"
 
 export function initialize(streamActions: TurboStreamActions) {
   TurboMorph.initialize(streamActions)
-  TurboReady.initialize(streamActions)
   Actions.register(streamActions)
 }
 

--- a/test/deprecated/invoke.test.js
+++ b/test/deprecated/invoke.test.js
@@ -1,0 +1,19 @@
+import sinon from 'sinon'
+import { assert } from '@open-wc/testing'
+import { executeStream, registerAction } from '../test_helpers'
+
+registerAction('invoke')
+
+describe('invoke', () => {
+  it('show deprecation warning', async () => {
+    sinon.replace(console, 'warn', sinon.fake())
+
+    const expectedWarning = "[TurboPower] The `invoke` Turbo Stream Action was removed from TurboPower. If you'd like to continue using this action please use the successor library instead. Read more here: https://github.com/hopsoft/turbo_boost-streams"
+
+    assert(!console.warn.calledWith(expectedWarning), `console.warn wasn't called with "${expectedWarning}"`)
+
+    await executeStream('<turbo-stream action="invoke"></turbo-stream>')
+
+    assert(console.warn.calledWith(expectedWarning), `console.warn wasn't called with "${expectedWarning}"`)
+  })
+})

--- a/types/turbo_ready/index.d.ts
+++ b/types/turbo_ready/index.d.ts
@@ -1,4 +1,0 @@
-declare module "turbo_ready" {
-  import { TurboStreamActions } from "@hotwired/turbo"
-  export function initialize(actions: TurboStreamActions): void
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,11 +269,6 @@
     "@types/sinon-chai" "^3.2.3"
     chai-a11y-axe "^1.3.2"
 
-"@popperjs/core@^2.9.3":
-  version "2.11.6"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
-  integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
-
 "@rollup/plugin-node-resolve@^13.0.4":
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz#da1c5c5ce8316cef96a2f823d111c1e4e498801c"
@@ -1928,14 +1923,6 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-flowbite@^1.5.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/flowbite/-/flowbite-1.5.3.tgz#99f0ba31b6d9a6fa8a1c25fb9aefa575a2a5efe6"
-  integrity sha512-e2OHfndxTHtGMqcPqvqwg3gGLg57hmIDVgE/BazMDccgirQ0JEtirKnbZZ4WSOIEhNDgO9pJZuyC8rRlcMm6pQ==
-  dependencies:
-    "@popperjs/core" "^2.9.3"
-    mini-svg-data-uri "^1.4.3"
-
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -2776,11 +2763,6 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
-
-mini-svg-data-uri@^1.4.3:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz#8ab0aabcdf8c29ad5693ca595af19dd2ead09939"
-  integrity sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -3967,13 +3949,6 @@ turbo-morph@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/turbo-morph/-/turbo-morph-0.1.0.tgz#1db6900ea5a96780e94915d3bcb9c9b0e45c442e"
   integrity sha512-+T7KQySPZS3MQYm4zHrAvGV7pdL8d/Tn5Dq51WlUNp6CCEQgWjS9ruiGbU1rb/pvFJa51HBm0tEH4aJiNxIrIQ==
-
-turbo_ready@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/turbo_ready/-/turbo_ready-0.1.0.tgz#4c1183face583d15359df7e54cf3d4a62a195967"
-  integrity sha512-ds9WLiCnZovCIaV2bGMHdwhnSXNDzi1HCGzDgcRyTVRJQ7LVSFK/d04jVsn26hEAKxW/PhzE1GOaemX8XZ8sxA==
-  dependencies:
-    flowbite "^1.5.3"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
This Pull Request deprecates the `invoke` stream action. If you'd like to continue using it you should use the successor library (`@turbo-boost/streams`) instead. 

TurboPower will still register a stubbed out `invoke` stream action if the action wasn't registered yet, so you get a deprecation warning in the browser console.