### PR TITLE
move `set_cookie` action

### DIFF
--- a/src/actions/browser.ts
+++ b/src/actions/browser.ts
@@ -8,12 +8,6 @@ export function scroll_into_view(this: StreamElement) {
   this.targetElements.forEach((element: Element) => element.scrollIntoView())
 }
 
-export function set_cookie(this: StreamElement) {
-  const cookie = this.getAttribute("cookie") || ""
-
-  document.cookie = cookie
-}
-
 export function set_focus(this: StreamElement) {
   this.targetElements.forEach((element: HTMLElement) => element.focus())
 }
@@ -33,7 +27,6 @@ export function set_title(this: StreamElement) {
 export function registerBrowserActions(streamActions: TurboStreamActions) {
   streamActions.reload = reload
   streamActions.scroll_into_view = scroll_into_view
-  streamActions.set_cookie = set_cookie
   streamActions.set_focus = set_focus
   streamActions.set_title = set_title
 }

--- a/src/actions/document.ts
+++ b/src/actions/document.ts
@@ -1,11 +1,18 @@
 import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 import { CookieStringBuilder } from "./document/cookie_string_builder"
 
+export function set_cookie(this: StreamElement) {
+  const cookie = this.getAttribute("cookie") || ""
+
+  document.cookie = cookie
+}
+
 export function set_cookie_item(this: StreamElement) {
   const cookieStringBuilder = new CookieStringBuilder(this)
   document.cookie = cookieStringBuilder.build()
 }
 
 export function registerDocumentActions(streamActions: TurboStreamActions) {
+  streamActions.set_cookie = set_cookie
   streamActions.set_cookie_item = set_cookie_item
 }

--- a/test/document/set_cookie.test.js
+++ b/test/document/set_cookie.test.js
@@ -1,0 +1,41 @@
+import sinon from "sinon"
+import { assert } from "@open-wc/testing"
+import { executeStream, registerAction } from "../test_helpers"
+
+registerAction("set_cookie")
+
+function documentCookieFake() {
+  return sinon.replaceSetter(document, "cookie", sinon.fake())
+}
+
+describe("set_cookie", () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it("should set the cookie", async () => {
+    const fake = documentCookieFake()
+
+    await executeStream(
+      `<turbo-stream
+        action="set_cookie"
+        cookie="foo=bar"></turbo-stream>`
+    )
+
+    assert.equal(fake.firstArg, "foo=bar")
+    assert.equal(fake.callCount, 1)
+  })
+
+  it("should set the cookie even with invalid values", async () => {
+    const fake = documentCookieFake()
+
+    await executeStream(
+      `<turbo-stream
+        action="set_cookie"
+        cookie="foo=bar; whatever;"></turbo-stream>`
+    )
+
+    assert.equal(fake.firstArg, "foo=bar; whatever;")
+    assert.equal(fake.callCount, 1)
+  })
+})


### PR DESCRIPTION
Hi 👋 

I hope I understood this correctly last week. This PR moves the implementation for `set_cookie` from `./browser` to `./document`. It also adds some simple tests for it.

Let me know what/if I can improve anything.