### PR TITLE
implement `notification` action

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,16 +2,17 @@ import { TurboStreamActions } from "@hotwired/turbo"
 
 import * as Attributes from "./actions/attributes"
 import * as Browser from "./actions/browser"
-import * as Document from "./actions/document"
-import * as DOM from "./actions/dom"
 import * as Debug from "./actions/debug"
 import * as Deprecated from "./actions/deprecated"
+import * as Document from "./actions/document"
+import * as DOM from "./actions/dom"
 import * as Events from "./actions/events"
 import * as Form from "./actions/form"
 import * as History from "./actions/history"
+import * as Notification from "./actions/notification"
 import * as Storage from "./actions/storage"
-import * as TurboFrame from "./actions/turbo_frame"
 import * as Turbo from "./actions/turbo"
+import * as TurboFrame from "./actions/turbo_frame"
 
 export * from "./actions/attributes"
 export * from "./actions/browser"
@@ -22,9 +23,10 @@ export * from "./actions/dom"
 export * from "./actions/events"
 export * from "./actions/form"
 export * from "./actions/history"
+export * from "./actions/notification"
 export * from "./actions/storage"
-export * from "./actions/turbo_frame"
 export * from "./actions/turbo"
+export * from "./actions/turbo_frame"
 
 export function register(streamActions: TurboStreamActions) {
   Attributes.registerAttributesActions(streamActions)
@@ -36,7 +38,8 @@ export function register(streamActions: TurboStreamActions) {
   Events.registerEventsActions(streamActions)
   Form.registerFormActions(streamActions)
   History.registerHistoryActions(streamActions)
+  Notification.registerNotificationActions(streamActions)
   Storage.registerStorageActions(streamActions)
-  TurboFrame.registerTurboFrameActions(streamActions)
   Turbo.registerTurboActions(streamActions)
+  TurboFrame.registerTurboFrameActions(streamActions)
 }

--- a/src/actions/notification.ts
+++ b/src/actions/notification.ts
@@ -20,11 +20,11 @@ const PERMITTED_ATTRIBUTES = [
 const createNotification = (streamElement: StreamElement) => {
   const title = streamElement.getAttribute("title") || ""
 
-  const options = Array.from(streamElement.attributes)
+  const attributes = Array.from(streamElement.attributes)
     .filter((attribute) => PERMITTED_ATTRIBUTES.includes(attribute.name))
-    .reduce((acc, attribute) => {
-      return { ...acc, [camelize(attribute.name)]: typecast(attribute.value) }
-    }, {})
+    .map((attribute) => [camelize(attribute.name), typecast(attribute.value))
+
+  const options = Object.fromEntries(attributes)
 
   new Notification(title, options)
 }

--- a/src/actions/notification.ts
+++ b/src/actions/notification.ts
@@ -1,0 +1,40 @@
+import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+
+type AttributeToNotificationOptionKeyMappingRow = [string, string, boolean]
+
+const ATTRIBUTE_TO_NOTIFICATION_OPTION_KEY_MAPPING: AttributeToNotificationOptionKeyMappingRow[] = [
+  ["dir", "dir", false],
+  ["lang", "lang", false],
+  ["badge", "badge", false],
+  ["body", "body", false],
+  ["tag", "tag", false],
+  ["icon", "icon", false],
+  ["image", "image", false],
+  ["data", "data", true],
+  ["vibrate", "vibrate", true],
+  ["renotify", "renotify", true],
+  ["require-interaction", "requireInteraction", true],
+  ["actions", "actions", true],
+  ["silent", "silent", true],
+]
+
+export function notification(this: StreamElement) {
+  const title = this.getAttribute("title") || ""
+
+  const options = ATTRIBUTE_TO_NOTIFICATION_OPTION_KEY_MAPPING.reduce((acc, [attributeName, optionKey, parseJson]) => {
+    const attributeValue = this.getAttribute(attributeName)
+
+    if (attributeValue !== null) {
+      const optionValue = parseJson ? JSON.parse(attributeValue) : attributeValue
+      return { ...acc, [optionKey]: optionValue }
+    } else {
+      return acc
+    }
+  }, {})
+
+  new Notification(title, options)
+}
+
+export function registerNotificationActions(streamActions: TurboStreamActions) {
+  streamActions.notification = notification
+}

--- a/src/actions/notification.ts
+++ b/src/actions/notification.ts
@@ -1,36 +1,30 @@
 import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+import { camelize, typecast } from "../utils"
 
-type AttributeToNotificationOptionKeyMappingRow = [string, string, boolean]
-
-const ATTRIBUTE_TO_NOTIFICATION_OPTION_KEY_MAPPING: AttributeToNotificationOptionKeyMappingRow[] = [
-  ["dir", "dir", false],
-  ["lang", "lang", false],
-  ["badge", "badge", false],
-  ["body", "body", false],
-  ["tag", "tag", false],
-  ["icon", "icon", false],
-  ["image", "image", false],
-  ["data", "data", false],
-  ["vibrate", "vibrate", true],
-  ["renotify", "renotify", true],
-  ["require-interaction", "requireInteraction", true],
-  ["actions", "actions", true],
-  ["silent", "silent", true],
+const PERMITTED_ATTRIBUTES = [
+  "dir",
+  "lang",
+  "badge",
+  "body",
+  "tag",
+  "icon",
+  "image",
+  "data",
+  "vibrate",
+  "renotify",
+  "require-interaction",
+  "actions",
+  "silent",
 ]
 
 const createNotification = (streamElement: StreamElement) => {
   const title = streamElement.getAttribute("title") || ""
 
-  const options = ATTRIBUTE_TO_NOTIFICATION_OPTION_KEY_MAPPING.reduce((acc, [attributeName, optionKey, parseJson]) => {
-    const attributeValue = streamElement.getAttribute(attributeName)
-
-    if (attributeValue !== null) {
-      const optionValue = parseJson ? JSON.parse(attributeValue) : attributeValue
-      return { ...acc, [optionKey]: optionValue }
-    } else {
-      return acc
-    }
-  }, {})
+  const options = Array.from(streamElement.attributes)
+    .filter((attribute) => PERMITTED_ATTRIBUTES.includes(attribute.name))
+    .reduce((acc, attribute) => {
+      return { ...acc, [camelize(attribute.name)]: typecast(attribute.value) }
+    }, {})
 
   new Notification(title, options)
 }

--- a/src/actions/notification.ts
+++ b/src/actions/notification.ts
@@ -22,7 +22,7 @@ const createNotification = (streamElement: StreamElement) => {
 
   const attributes = Array.from(streamElement.attributes)
     .filter((attribute) => PERMITTED_ATTRIBUTES.includes(attribute.name))
-    .map((attribute) => [camelize(attribute.name), typecast(attribute.value))
+    .map((attribute) => [camelize(attribute.name), typecast(attribute.value)])
 
   const options = Object.fromEntries(attributes)
 

--- a/src/actions/notification.ts
+++ b/src/actions/notification.ts
@@ -10,7 +10,7 @@ const ATTRIBUTE_TO_NOTIFICATION_OPTION_KEY_MAPPING: AttributeToNotificationOptio
   ["tag", "tag", false],
   ["icon", "icon", false],
   ["image", "image", false],
-  ["data", "data", true],
+  ["data", "data", false],
   ["vibrate", "vibrate", true],
   ["renotify", "renotify", true],
   ["require-interaction", "requireInteraction", true],
@@ -18,11 +18,11 @@ const ATTRIBUTE_TO_NOTIFICATION_OPTION_KEY_MAPPING: AttributeToNotificationOptio
   ["silent", "silent", true],
 ]
 
-export function notification(this: StreamElement) {
-  const title = this.getAttribute("title") || ""
+const createNotification = (streamElement: StreamElement) => {
+  const title = streamElement.getAttribute("title") || ""
 
   const options = ATTRIBUTE_TO_NOTIFICATION_OPTION_KEY_MAPPING.reduce((acc, [attributeName, optionKey, parseJson]) => {
-    const attributeValue = this.getAttribute(attributeName)
+    const attributeValue = streamElement.getAttribute(attributeName)
 
     if (attributeValue !== null) {
       const optionValue = parseJson ? JSON.parse(attributeValue) : attributeValue
@@ -33,6 +33,20 @@ export function notification(this: StreamElement) {
   }, {})
 
   new Notification(title, options)
+}
+
+export function notification(this: StreamElement) {
+  if (!window.Notification) {
+    alert("This browser does not support desktop notification")
+  } else if (Notification.permission === "granted") {
+    createNotification(this)
+  } else if (Notification.permission !== "denied") {
+    Notification.requestPermission().then((permission) => {
+      if (permission === "granted") {
+        createNotification(this)
+      }
+    })
+  }
 }
 
 export function registerNotificationActions(streamActions: TurboStreamActions) {

--- a/test/notifications/create_notification.test.js
+++ b/test/notifications/create_notification.test.js
@@ -1,0 +1,88 @@
+import sinon from "sinon"
+import { assert } from "@open-wc/testing"
+import { executeStream, registerAction } from "../test_helpers"
+
+registerAction("notification")
+
+function notificationSpy() {
+  return sinon.spy(window, "Notification")
+}
+
+describe("notification", () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it("should create the notification, title only", async () => {
+    const spy = notificationSpy()
+
+    await executeStream(
+      `<turbo-stream
+        action="notification"
+        title="May I have your attention..."
+        ></turbo-stream>`
+    )
+
+    assert.equal(spy.callCount, 1)
+    assert.equal(spy.firstCall.firstArg, "May I have your attention...")
+    assert.equal(spy.firstCall.secondArg, null)
+  })
+
+  it("should create the notification, title and options", async () => {
+    const spy = notificationSpy()
+
+    await executeStream(
+      `<turbo-stream
+        action="notification"
+        title="May I have your attention..."
+        dir="ltr"
+        lang="EN"
+        badge="https://example.com/badge.png"
+        body="This is displayed below the title."
+        tag="Demo"
+        icon="https://example.com/icon.png"
+        image="https://example.com/image.png"
+        data='{"arbitrary": "data"}'
+        vibrate="[200, 100, 200]"
+        renotify="true"
+        require-interaction="true"
+        ></turbo-stream>`
+    )
+
+    assert.equal(spy.callCount, 1)
+    assert.equal(spy.firstCall.firstArg, "May I have your attention...")
+    assert.deepEqual(spy.firstCall.args[1], {
+      dir: "ltr",
+      lang: "EN",
+      badge: "https://example.com/badge.png",
+      body: "This is displayed below the title.",
+      tag: "Demo",
+      icon: "https://example.com/icon.png",
+      image: "https://example.com/image.png",
+      data: { arbitrary: "data" },
+      vibrate: [200, 100, 200],
+      renotify: true,
+      requireInteraction: true,
+    })
+  })
+
+  it.skip("should create the notification, title and options that are supported using ServiceWorkers", async () => {
+    const spy = notificationSpy()
+
+    await executeStream(
+      `<turbo-stream
+        action="notification"
+        title="May I have your attention..."
+        actions='[{"action": "respond", "title": "Please respond", "icon": "https://example.com/icon.png"}]'
+        silent="true"
+        ></turbo-stream>`
+    )
+
+    assert.equal(spy.callCount, 1)
+    assert.equal(spy.firstCall.firstArg, "May I have your attention...")
+    assert.deepEqual(spy.firstCall.args[1], {
+      actions: [{ action: "respond", title: "Please respond", icon: "https://example.com/icon.png" }],
+      silent: true,
+    })
+  })
+})

--- a/test/notifications/create_notification.test.js
+++ b/test/notifications/create_notification.test.js
@@ -9,104 +9,112 @@ describe("notification", () => {
     sinon.restore()
   })
 
-  it("grants permission after default", async () => {
-    const stub = sinon.stub(window, "Notification")
-    sinon.stub(Notification, "permission").value("default")
-    sinon.stub(Notification, "requestPermission").resolves("granted")
+  context("Notification is not supported", () => {
+    it("alerts with a message", async () => {
+      const stub = sinon.stub(window, "Notification").value(undefined)
+      const mock = sinon
+        .mock(window)
+        .expects("alert")
+        .once()
+        .withArgs("This browser does not support desktop notification")
 
-    await executeStream(`<turbo-stream action="notification"></turbo-stream>`)
-
-    assert.equal(stub.callCount, 1)
-  })
-
-  it("rejects permission after default", async () => {
-    const stub = sinon.stub(window, "Notification")
-    sinon.stub(Notification, "permission").value("default")
-    sinon.stub(Notification, "requestPermission").resolves("denied")
-
-    await executeStream(`<turbo-stream action="notification" ></turbo-stream>`)
-
-    assert.equal(stub.callCount, 0)
-  })
-
-  it("creates no notification if denied", async () => {
-    const stub = sinon.stub(window, "Notification")
-    sinon.stub(Notification, "permission").value("denied")
-
-    await executeStream(`<turbo-stream action="notification" ></turbo-stream>`)
-
-    assert.equal(stub.callCount, 0)
-  })
-
-  it("creates the notifiaction if granted", async () => {
-    const stub = sinon.stub(window, "Notification")
-    sinon.stub(Notification, "permission").value("granted")
-
-    await executeStream(
-      `<turbo-stream
-        action="notification"
-        title="May I have your attention..."
-        ></turbo-stream>`
-    )
-
-    assert.equal(stub.callCount, 1)
-    assert.equal(stub.firstCall.firstArg, "May I have your attention...")
-    assert.equal(stub.firstCall.secondArg, null)
-  })
-
-  it("should create the notification, title and options", async () => {
-    const stub = sinon.stub(window, "Notification")
-    sinon.stub(Notification, "permission").value("granted")
-
-    await executeStream(
-      `<turbo-stream
-        action="notification"
-        title="May I have your attention..."
-        dir="ltr"
-        lang="EN"
-        badge="https://example.com/badge.png"
-        body="This is displayed below the title."
-        tag="Demo"
-        icon="https://example.com/icon.png"
-        image="https://example.com/image.png"
-        data='{"arbitrary": "data"}'
-        vibrate="[200, 100, 200]"
-        renotify="true"
-        require-interaction="true"
-        actions='[{"action": "respond", "title": "Please respond", "icon": "https://example.com/icon.png"}]'
-        silent="true"
-        ></turbo-stream>`
-    )
-
-    assert.equal(stub.callCount, 1)
-    assert.equal(stub.firstCall.firstArg, "May I have your attention...")
-    assert.deepEqual(stub.firstCall.args[1], {
-      dir: "ltr",
-      lang: "EN",
-      badge: "https://example.com/badge.png",
-      body: "This is displayed below the title.",
-      tag: "Demo",
-      icon: "https://example.com/icon.png",
-      image: "https://example.com/image.png",
-      data: '{"arbitrary": "data"}',
-      vibrate: [200, 100, 200],
-      renotify: true,
-      requireInteraction: true,
-      actions: [{ action: "respond", title: "Please respond", icon: "https://example.com/icon.png" }],
-      silent: true,
+      await executeStream(`<turbo-stream action="notification"></turbo-stream>`)
+      assert.equal(stub.callCount, 0)
+      mock.verify()
     })
   })
 
-  it("handles if Notification is not available", async () => {
-    const stub = sinon.stub(window, "Notification").value(undefined)
-    const mock = sinon
-      .mock(window)
-      .expects("alert")
-      .once()
-      .withArgs("This browser does not support desktop notification")
+  context("requestPermission is required", () => {
+    it("permission is granted", async () => {
+      const stub = sinon.stub(window, "Notification")
+      sinon.stub(Notification, "permission").value("default")
+      sinon.stub(Notification, "requestPermission").resolves("granted")
 
-    await executeStream(`<turbo-stream action="notification"></turbo-stream>`)
-    assert.equal(stub.callCount, 0)
-    mock.verify()
+      await executeStream(`<turbo-stream action="notification"></turbo-stream>`)
+
+      assert.equal(stub.callCount, 1)
+    })
+
+    it("permission is denied", async () => {
+      const stub = sinon.stub(window, "Notification")
+      sinon.stub(Notification, "permission").value("default")
+      sinon.stub(Notification, "requestPermission").resolves("denied")
+
+      await executeStream(`<turbo-stream action="notification" ></turbo-stream>`)
+
+      assert.equal(stub.callCount, 0)
+    })
+  })
+
+  context("permission was denied", () => {
+    it("creates no notification", async () => {
+      const stub = sinon.stub(window, "Notification")
+      sinon.stub(Notification, "permission").value("denied")
+
+      await executeStream(`<turbo-stream action="notification" ></turbo-stream>`)
+
+      assert.equal(stub.callCount, 0)
+    })
+  })
+
+  context("permission was granted", () => {
+    it("creates the notification with title only", async () => {
+      const stub = sinon.stub(window, "Notification")
+      sinon.stub(Notification, "permission").value("granted")
+
+      await executeStream(
+        `<turbo-stream
+          action="notification"
+          title="May I have your attention..."
+          ></turbo-stream>`
+      )
+
+      assert.equal(stub.callCount, 1)
+      assert.equal(stub.firstCall.firstArg, "May I have your attention...")
+      assert.equal(stub.firstCall.secondArg, null)
+    })
+
+    it("creates the notification with title and options", async () => {
+      const stub = sinon.stub(window, "Notification")
+      sinon.stub(Notification, "permission").value("granted")
+
+      await executeStream(
+        `<turbo-stream
+          action="notification"
+          title="May I have your attention..."
+          dir="ltr"
+          lang="EN"
+          badge="https://example.com/badge.png"
+          body="This is displayed below the title."
+          tag="Demo"
+          icon="https://example.com/icon.png"
+          image="https://example.com/image.png"
+          data='{"arbitrary": "data"}'
+          vibrate="[200, 100, 200]"
+          renotify="true"
+          require-interaction="true"
+          actions='[{"action": "respond", "title": "Please respond", "icon": "https://example.com/icon.png"}]'
+          silent="true"
+          ></turbo-stream>`
+      )
+
+      assert.equal(stub.callCount, 1)
+      assert.equal(stub.firstCall.firstArg, "May I have your attention...")
+      assert.deepEqual(stub.firstCall.args[1], {
+        dir: "ltr",
+        lang: "EN",
+        badge: "https://example.com/badge.png",
+        body: "This is displayed below the title.",
+        tag: "Demo",
+        icon: "https://example.com/icon.png",
+        image: "https://example.com/image.png",
+        data: { arbitrary: "data" },
+        vibrate: [200, 100, 200],
+        renotify: true,
+        requireInteraction: true,
+        actions: [{ action: "respond", title: "Please respond", icon: "https://example.com/icon.png" }],
+        silent: true,
+      })
+    })
   })
 })

--- a/test/notifications/create_notification.test.js
+++ b/test/notifications/create_notification.test.js
@@ -4,8 +4,8 @@ import { executeStream, registerAction } from "../test_helpers"
 
 registerAction("notification")
 
-function notificationSpy() {
-  return sinon.spy(window, "Notification")
+function notificationStub() {
+  return sinon.stub(window, "Notification")
 }
 
 describe("notification", () => {
@@ -14,7 +14,7 @@ describe("notification", () => {
   })
 
   it("should create the notification, title only", async () => {
-    const spy = notificationSpy()
+    const stub = notificationStub()
 
     await executeStream(
       `<turbo-stream
@@ -23,13 +23,13 @@ describe("notification", () => {
         ></turbo-stream>`
     )
 
-    assert.equal(spy.callCount, 1)
-    assert.equal(spy.firstCall.firstArg, "May I have your attention...")
-    assert.equal(spy.firstCall.secondArg, null)
+    assert.equal(stub.callCount, 1)
+    assert.equal(stub.firstCall.firstArg, "May I have your attention...")
+    assert.equal(stub.firstCall.secondArg, null)
   })
 
   it("should create the notification, title and options", async () => {
-    const spy = notificationSpy()
+    const stub = notificationStub()
 
     await executeStream(
       `<turbo-stream
@@ -46,12 +46,14 @@ describe("notification", () => {
         vibrate="[200, 100, 200]"
         renotify="true"
         require-interaction="true"
+        actions='[{"action": "respond", "title": "Please respond", "icon": "https://example.com/icon.png"}]'
+        silent="true"
         ></turbo-stream>`
     )
 
-    assert.equal(spy.callCount, 1)
-    assert.equal(spy.firstCall.firstArg, "May I have your attention...")
-    assert.deepEqual(spy.firstCall.args[1], {
+    assert.equal(stub.callCount, 1)
+    assert.equal(stub.firstCall.firstArg, "May I have your attention...")
+    assert.deepEqual(stub.firstCall.args[1], {
       dir: "ltr",
       lang: "EN",
       badge: "https://example.com/badge.png",
@@ -63,24 +65,6 @@ describe("notification", () => {
       vibrate: [200, 100, 200],
       renotify: true,
       requireInteraction: true,
-    })
-  })
-
-  it.skip("should create the notification, title and options that are supported using ServiceWorkers", async () => {
-    const spy = notificationSpy()
-
-    await executeStream(
-      `<turbo-stream
-        action="notification"
-        title="May I have your attention..."
-        actions='[{"action": "respond", "title": "Please respond", "icon": "https://example.com/icon.png"}]'
-        silent="true"
-        ></turbo-stream>`
-    )
-
-    assert.equal(spy.callCount, 1)
-    assert.equal(spy.firstCall.firstArg, "May I have your attention...")
-    assert.deepEqual(spy.firstCall.args[1], {
       actions: [{ action: "respond", title: "Please respond", icon: "https://example.com/icon.png" }],
       silent: true,
     })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "es2015", "scripthost"],
+    "lib": ["dom", "es2019", "scripthost"],
     "module": "es2015",
     "moduleResolution": "node",
     "noUnusedLocals": true,


### PR DESCRIPTION
Hi 👋 

This is an idea resp. attempt to implement #4 

```ruby
# initial signature from the issue:
turbo_stream.notification(title, options, **attributes)
```

However... instead of having one `options` argument, I took the approach of making the options available individually... I am unsure how useful/usless this is. What do you think?

Also, there's one skipped test at the moment.
If we use the `actions` and/or `silent` option, the browser log mentions this:

```
 🚧 Browser logs:
      TypeError: Failed to construct 'Notification': Actions are only supported for persistent notifications shown using ServiceWorkerRegistration.showNotification().
        at Function.invoke (node_modules/sinon/pkg/sinon-esm.js:2386:27)
        at new Notification (node_modules/sinon/pkg/sinon-esm.js:2705:26)
        at StreamElement.rt (dist/index.js:1:12153)
        at Object.renderElement [as render] (node_modules/@hotwired/turbo/dist/turbo.es2017-esm.js:3656:26)
        at node_modules/@hotwired/turbo/dist/turbo.es2017-esm.js:3675:36
        at async StreamElement.connectedCallback (node_modules/@hotwired/turbo/dist/turbo.es2017-esm.js:3660:13)
```

Do you have an idea how to resolve this, if at all?
