### PR TITLE
Change `turbo_action` attribute to `turbo-action`

### DIFF
--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -10,7 +10,7 @@ declare global {
 
 export function redirect_to(this: StreamElement) {
   const url = this.getAttribute("url") || "/"
-  const turboAction = (this.getAttribute("turbo_action") || "advance") as Action
+  const turboAction = (this.getAttribute("turbo-action") || "advance") as Action
   const turbo = this.getAttribute("turbo") === "true"
 
   if (turbo && window.Turbo) {


### PR DESCRIPTION
All attributes use dasherized attribute names so we should also use `turbo-action` in favor of `turbo_action` for the `redirect_to` action.