### PR TITLE
Add tests for `redirect_to` action

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,9 @@
         "context": true,
         "it": true,
         "beforeEach": true,
-        "afterEach": true
+        "afterEach": true,
+        "Turbo": true,
+        "TurboPowerLocation": true
       }
     }
   ],

--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -1,6 +1,7 @@
 import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 import * as Turbo from "@hotwired/turbo"
 import { Action } from "@hotwired/turbo/dist/types/core/types"
+import Proxy from "../proxy"
 
 declare global {
   interface Window {
@@ -16,7 +17,7 @@ export function redirect_to(this: StreamElement) {
   if (turbo && window.Turbo) {
     window.Turbo.visit(url, { action: turboAction })
   } else {
-    window.location.href = url
+    Proxy.location.assign(url)
   }
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,11 @@
+declare global {
+  interface Window {
+    TurboPowerLocation: typeof window.location
+  }
+}
+
+export default {
+  get location() {
+    return window.TurboPowerLocation || window.location;
+  }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,6 +6,6 @@ declare global {
 
 export default {
   get location() {
-    return window.TurboPowerLocation || window.location;
-  }
+    return window.TurboPowerLocation || window.location
+  },
 }

--- a/test/turbo/redirect_to.test.js
+++ b/test/turbo/redirect_to.test.js
@@ -7,7 +7,7 @@ registerAction("redirect_to")
 describe("redirect_to", () => {
   beforeEach(() => {
     window.TurboPowerLocation = {
-      assign: sinon.stub()
+      assign: sinon.stub(),
     }
   })
 
@@ -18,7 +18,7 @@ describe("redirect_to", () => {
 
   context("turbo attribute", () => {
     it("doesn't use Turbo by default", async () => {
-      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
       await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080"></turbo-stream>`)
 
@@ -27,20 +27,22 @@ describe("redirect_to", () => {
     })
 
     it("uses Turbo if true", async () => {
-      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
       await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080" turbo="true"></turbo-stream>`)
 
-      const expected = ['http://localhost:8080', { action: 'advance' }]
+      const expected = ["http://localhost:8080", { action: "advance" }]
 
       assert.equal(Turbo.visit.callCount, 1)
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("doesn't use Turbo if false", async () => {
-      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
-      await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080" turbo="false"></turbo-stream>`)
+      await executeStream(
+        `<turbo-stream action="redirect_to" url="http://localhost:8080" turbo="false"></turbo-stream>`
+      )
 
       assert.equal(Turbo.visit.callCount, 0)
       assert.equal(TurboPowerLocation.assign.callCount, 1)
@@ -49,33 +51,37 @@ describe("redirect_to", () => {
 
   context("turbo_action attribute", () => {
     it("uses advance by default", async () => {
-      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
       await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080" turbo="true"></turbo-stream>`)
 
-      const expected = ['http://localhost:8080', { action: 'advance' }]
+      const expected = ["http://localhost:8080", { action: "advance" }]
 
       assert.equal(Turbo.visit.callCount, 1)
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("uses replace", async () => {
-      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
-      await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080" turbo-action="replace" turbo="true"></turbo-stream>`)
+      await executeStream(
+        `<turbo-stream action="redirect_to" url="http://localhost:8080" turbo-action="replace" turbo="true"></turbo-stream>`
+      )
 
-      const expected = ['http://localhost:8080', { action: 'replace' }]
+      const expected = ["http://localhost:8080", { action: "replace" }]
 
       assert.equal(Turbo.visit.callCount, 1)
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("uses restore", async () => {
-      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
-      await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080" turbo-action="restore" turbo="true"></turbo-stream>`)
+      await executeStream(
+        `<turbo-stream action="redirect_to" url="http://localhost:8080" turbo-action="restore" turbo="true"></turbo-stream>`
+      )
 
-      const expected = ['http://localhost:8080', { action: 'restore' }]
+      const expected = ["http://localhost:8080", { action: "restore" }]
 
       assert.equal(Turbo.visit.callCount, 1)
       assert.deepEqual(Turbo.visit.args[0], expected)
@@ -84,44 +90,44 @@ describe("redirect_to", () => {
 
   context("url attribute", () => {
     it("uses / as fallback", async () => {
-      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
       await executeStream(`<turbo-stream action="redirect_to" turbo="true"></turbo-stream>`)
 
-      const expected = ['/', { action: 'advance' }]
+      const expected = ["/", { action: "advance" }]
 
       assert.equal(Turbo.visit.callCount, 1)
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("uses / as fallback with url attribute without value", async () => {
-      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
       await executeStream(`<turbo-stream action="redirect_to" url turbo="true"></turbo-stream>`)
 
-      const expected = ['/', { action: 'advance' }]
+      const expected = ["/", { action: "advance" }]
 
       assert.equal(Turbo.visit.callCount, 1)
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("uses / as fallback with empty url attribute", async () => {
-      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
       await executeStream(`<turbo-stream action="redirect_to" url="" turbo="true"></turbo-stream>`)
 
-      const expected = ['/', { action: 'advance' }]
+      const expected = ["/", { action: "advance" }]
 
       assert.equal(Turbo.visit.callCount, 1)
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("uses the provided url value", async () => {
-      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
       await executeStream(`<turbo-stream action="redirect_to" url="/path/to/somewhere" turbo="true"></turbo-stream>`)
 
-      const expected = ['/path/to/somewhere', { action: 'advance' }]
+      const expected = ["/path/to/somewhere", { action: "advance" }]
 
       assert.equal(Turbo.visit.callCount, 1)
       assert.deepEqual(Turbo.visit.args[0], expected)

--- a/test/turbo/redirect_to.test.js
+++ b/test/turbo/redirect_to.test.js
@@ -1,0 +1,121 @@
+import sinon from "sinon"
+import { assert } from "@open-wc/testing"
+import { executeStream, registerAction } from "../test_helpers"
+
+registerAction("redirect_to")
+
+describe("redirect_to", () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  context("turbo attribute", () => {
+    it("doesn't use Turbo by default", async () => {
+      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080"></turbo-stream>`)
+
+      assert.deepEqual(0, turbo.visit.callCount)
+    })
+
+    it("uses Turbo by if true", async () => {
+      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080" turbo="true"></turbo-stream>`)
+
+      const expected = ['http://localhost:8080', { action: 'advance' }]
+
+      assert.deepEqual(1, turbo.visit.callCount)
+      assert.deepEqual(expected, turbo.visit.args[0])
+    })
+
+    it("doesn't use Turbo if false", async () => {
+      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080" turbo="false"></turbo-stream>`)
+
+      assert.deepEqual(0, turbo.visit.callCount)
+    })
+  })
+
+  context("turbo_action attribute", () => {
+    it("uses advance by default", async () => {
+      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080" turbo="true"></turbo-stream>`)
+
+      const expected = ['http://localhost:8080', { action: 'advance' }]
+
+      assert.deepEqual(1, turbo.visit.callCount)
+      assert.deepEqual(expected, turbo.visit.args[0])
+    })
+
+    it("uses replace", async () => {
+      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080" turbo-action="replace" turbo="true"></turbo-stream>`)
+
+      const expected = ['http://localhost:8080', { action: 'replace' }]
+
+      assert.deepEqual(1, turbo.visit.callCount)
+      assert.deepEqual(expected, turbo.visit.args[0])
+    })
+
+    it("uses restore", async () => {
+      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080" turbo-action="restore" turbo="true"></turbo-stream>`)
+
+      const expected = ['http://localhost:8080', { action: 'restore' }]
+
+      assert.deepEqual(1, turbo.visit.callCount)
+      assert.deepEqual(expected, turbo.visit.args[0])
+    })
+  })
+
+  context("url attribute", () => {
+    it("uses / as fallback", async () => {
+      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(`<turbo-stream action="redirect_to" turbo="true"></turbo-stream>`)
+
+      const expected = ['/', { action: 'advance' }]
+
+      assert.deepEqual(1, turbo.visit.callCount)
+      assert.deepEqual(expected, turbo.visit.args[0])
+    })
+
+    it("uses / as fallback with url attribute without value", async () => {
+      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(`<turbo-stream action="redirect_to" url turbo="true"></turbo-stream>`)
+
+      const expected = ['/', { action: 'advance' }]
+
+      assert.deepEqual(1, turbo.visit.callCount)
+      assert.deepEqual(expected, turbo.visit.args[0])
+    })
+
+    it("uses / as fallback with empty url attribute", async () => {
+      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(`<turbo-stream action="redirect_to" url="" turbo="true"></turbo-stream>`)
+
+      const expected = ['/', { action: 'advance' }]
+
+      assert.deepEqual(1, turbo.visit.callCount)
+      assert.deepEqual(expected, turbo.visit.args[0])
+    })
+
+    it("uses the provided url value", async () => {
+      const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(`<turbo-stream action="redirect_to" url="/path/to/somewhere" turbo="true"></turbo-stream>`)
+
+      const expected = ['/path/to/somewhere', { action: 'advance' }]
+
+      assert.deepEqual(1, turbo.visit.callCount)
+      assert.deepEqual(expected, turbo.visit.args[0])
+    })
+  })
+})

--- a/test/turbo/redirect_to.test.js
+++ b/test/turbo/redirect_to.test.js
@@ -5,8 +5,15 @@ import { executeStream, registerAction } from "../test_helpers"
 registerAction("redirect_to")
 
 describe("redirect_to", () => {
+  beforeEach(() => {
+    window.TurboPowerLocation = {
+      assign: sinon.stub()
+    }
+  })
+
   afterEach(() => {
     sinon.restore()
+    window.TurboPowerLocation = undefined
   })
 
   context("turbo attribute", () => {

--- a/test/turbo/redirect_to.test.js
+++ b/test/turbo/redirect_to.test.js
@@ -22,18 +22,19 @@ describe("redirect_to", () => {
 
       await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080"></turbo-stream>`)
 
-      assert.deepEqual(0, turbo.visit.callCount)
+      assert.equal(Turbo.visit.callCount, 0)
+      assert.equal(TurboPowerLocation.assign.callCount, 1)
     })
 
-    it("uses Turbo by if true", async () => {
+    it("uses Turbo if true", async () => {
       const turbo = sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
       await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080" turbo="true"></turbo-stream>`)
 
       const expected = ['http://localhost:8080', { action: 'advance' }]
 
-      assert.deepEqual(1, turbo.visit.callCount)
-      assert.deepEqual(expected, turbo.visit.args[0])
+      assert.equal(Turbo.visit.callCount, 1)
+      assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("doesn't use Turbo if false", async () => {
@@ -41,7 +42,8 @@ describe("redirect_to", () => {
 
       await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080" turbo="false"></turbo-stream>`)
 
-      assert.deepEqual(0, turbo.visit.callCount)
+      assert.equal(Turbo.visit.callCount, 0)
+      assert.equal(TurboPowerLocation.assign.callCount, 1)
     })
   })
 
@@ -53,8 +55,8 @@ describe("redirect_to", () => {
 
       const expected = ['http://localhost:8080', { action: 'advance' }]
 
-      assert.deepEqual(1, turbo.visit.callCount)
-      assert.deepEqual(expected, turbo.visit.args[0])
+      assert.equal(Turbo.visit.callCount, 1)
+      assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("uses replace", async () => {
@@ -64,8 +66,8 @@ describe("redirect_to", () => {
 
       const expected = ['http://localhost:8080', { action: 'replace' }]
 
-      assert.deepEqual(1, turbo.visit.callCount)
-      assert.deepEqual(expected, turbo.visit.args[0])
+      assert.equal(Turbo.visit.callCount, 1)
+      assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("uses restore", async () => {
@@ -75,8 +77,8 @@ describe("redirect_to", () => {
 
       const expected = ['http://localhost:8080', { action: 'restore' }]
 
-      assert.deepEqual(1, turbo.visit.callCount)
-      assert.deepEqual(expected, turbo.visit.args[0])
+      assert.equal(Turbo.visit.callCount, 1)
+      assert.deepEqual(Turbo.visit.args[0], expected)
     })
   })
 
@@ -88,8 +90,8 @@ describe("redirect_to", () => {
 
       const expected = ['/', { action: 'advance' }]
 
-      assert.deepEqual(1, turbo.visit.callCount)
-      assert.deepEqual(expected, turbo.visit.args[0])
+      assert.equal(Turbo.visit.callCount, 1)
+      assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("uses / as fallback with url attribute without value", async () => {
@@ -99,8 +101,8 @@ describe("redirect_to", () => {
 
       const expected = ['/', { action: 'advance' }]
 
-      assert.deepEqual(1, turbo.visit.callCount)
-      assert.deepEqual(expected, turbo.visit.args[0])
+      assert.equal(Turbo.visit.callCount, 1)
+      assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("uses / as fallback with empty url attribute", async () => {
@@ -110,8 +112,8 @@ describe("redirect_to", () => {
 
       const expected = ['/', { action: 'advance' }]
 
-      assert.deepEqual(1, turbo.visit.callCount)
-      assert.deepEqual(expected, turbo.visit.args[0])
+      assert.equal(Turbo.visit.callCount, 1)
+      assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("uses the provided url value", async () => {
@@ -121,8 +123,8 @@ describe("redirect_to", () => {
 
       const expected = ['/path/to/somewhere', { action: 'advance' }]
 
-      assert.deepEqual(1, turbo.visit.callCount)
-      assert.deepEqual(expected, turbo.visit.args[0])
+      assert.equal(Turbo.visit.callCount, 1)
+      assert.deepEqual(Turbo.visit.args[0], expected)
     })
   })
 })


### PR DESCRIPTION
This pull request adds tests for the `redirect_to` action. This ensures that #37 works properly and also ensures we can reliably introduce the change in #13.