### PR TITLE
Use `Turbo.visit()` by default in `redirect_to` action

### DIFF
--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -12,7 +12,7 @@ declare global {
 export function redirect_to(this: StreamElement) {
   const url = this.getAttribute("url") || "/"
   const turboAction = (this.getAttribute("turbo-action") || "advance") as Action
-  const turbo = this.getAttribute("turbo") === "true"
+  const turbo = this.getAttribute("turbo") !== "false"
 
   if (turbo && window.Turbo) {
     window.Turbo.visit(url, { action: turboAction })

--- a/test/turbo/redirect_to.test.js
+++ b/test/turbo/redirect_to.test.js
@@ -50,6 +50,7 @@ describe("redirect_to", () => {
 
       assert.equal(Turbo.visit.callCount, 0)
       assert.equal(TurboPowerLocation.assign.callCount, 1)
+      assert.deepEqual(TurboPowerLocation.assign.args[0], ["http://localhost:8080"])
     })
   })
 

--- a/test/turbo/redirect_to.test.js
+++ b/test/turbo/redirect_to.test.js
@@ -17,23 +17,27 @@ describe("redirect_to", () => {
   })
 
   context("turbo attribute", () => {
-    it("doesn't use Turbo by default", async () => {
+    it("uses Turbo by default", async () => {
       sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
       await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080"></turbo-stream>`)
 
-      assert.equal(Turbo.visit.callCount, 0)
-      assert.equal(TurboPowerLocation.assign.callCount, 1)
+      const expected = ["http://localhost:8080", { action: "advance" }]
+
+      assert.equal(Turbo.visit.callCount, 1)
+      assert.equal(TurboPowerLocation.assign.callCount, 0)
+      assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("uses Turbo if true", async () => {
       sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
-      await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080" turbo="true"></turbo-stream>`)
+      await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080"></turbo-stream>`)
 
       const expected = ["http://localhost:8080", { action: "advance" }]
 
       assert.equal(Turbo.visit.callCount, 1)
+      assert.equal(TurboPowerLocation.assign.callCount, 0)
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
@@ -53,11 +57,12 @@ describe("redirect_to", () => {
     it("uses advance by default", async () => {
       sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
-      await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080" turbo="true"></turbo-stream>`)
+      await executeStream(`<turbo-stream action="redirect_to" url="http://localhost:8080"></turbo-stream>`)
 
       const expected = ["http://localhost:8080", { action: "advance" }]
 
       assert.equal(Turbo.visit.callCount, 1)
+      assert.equal(TurboPowerLocation.assign.callCount, 0)
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
@@ -65,12 +70,13 @@ describe("redirect_to", () => {
       sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
       await executeStream(
-        `<turbo-stream action="redirect_to" url="http://localhost:8080" turbo-action="replace" turbo="true"></turbo-stream>`
+        `<turbo-stream action="redirect_to" url="http://localhost:8080" turbo-action="replace"></turbo-stream>`
       )
 
       const expected = ["http://localhost:8080", { action: "replace" }]
 
       assert.equal(Turbo.visit.callCount, 1)
+      assert.equal(TurboPowerLocation.assign.callCount, 0)
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
@@ -78,12 +84,13 @@ describe("redirect_to", () => {
       sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
       await executeStream(
-        `<turbo-stream action="redirect_to" url="http://localhost:8080" turbo-action="restore" turbo="true"></turbo-stream>`
+        `<turbo-stream action="redirect_to" url="http://localhost:8080" turbo-action="restore"></turbo-stream>`
       )
 
       const expected = ["http://localhost:8080", { action: "restore" }]
 
       assert.equal(Turbo.visit.callCount, 1)
+      assert.equal(TurboPowerLocation.assign.callCount, 0)
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
   })
@@ -92,44 +99,48 @@ describe("redirect_to", () => {
     it("uses / as fallback", async () => {
       sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
-      await executeStream(`<turbo-stream action="redirect_to" turbo="true"></turbo-stream>`)
+      await executeStream(`<turbo-stream action="redirect_to"></turbo-stream>`)
 
       const expected = ["/", { action: "advance" }]
 
       assert.equal(Turbo.visit.callCount, 1)
+      assert.equal(TurboPowerLocation.assign.callCount, 0)
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("uses / as fallback with url attribute without value", async () => {
       sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
-      await executeStream(`<turbo-stream action="redirect_to" url turbo="true"></turbo-stream>`)
+      await executeStream(`<turbo-stream action="redirect_to" url></turbo-stream>`)
 
       const expected = ["/", { action: "advance" }]
 
       assert.equal(Turbo.visit.callCount, 1)
+      assert.equal(TurboPowerLocation.assign.callCount, 0)
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("uses / as fallback with empty url attribute", async () => {
       sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
-      await executeStream(`<turbo-stream action="redirect_to" url="" turbo="true"></turbo-stream>`)
+      await executeStream(`<turbo-stream action="redirect_to" url=""></turbo-stream>`)
 
       const expected = ["/", { action: "advance" }]
 
       assert.equal(Turbo.visit.callCount, 1)
+      assert.equal(TurboPowerLocation.assign.callCount, 0)
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
 
     it("uses the provided url value", async () => {
       sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
-      await executeStream(`<turbo-stream action="redirect_to" url="/path/to/somewhere" turbo="true"></turbo-stream>`)
+      await executeStream(`<turbo-stream action="redirect_to" url="/path/to/somewhere"></turbo-stream>`)
 
       const expected = ["/path/to/somewhere", { action: "advance" }]
 
       assert.equal(Turbo.visit.callCount, 1)
+      assert.equal(TurboPowerLocation.assign.callCount, 0)
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
   })


### PR DESCRIPTION
Resolves #13 