### PR TITLE
Implement `turbo_progress_bar` actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,16 +129,25 @@ Checkout the instructions in the [`turbo_power-rails`](https://github.com/marcor
 * `turbo_stream.notification(title, options, **attributes)`
 
 
+### Turbo Actions
+
+* `turbo_stream.redirect_to(url, turbo_action = nil, **attributes)`
+* `turbo_stream.turbo_clear_cache()`
+
+
+### Turbo Progress Bar Actions
+
+* `turbo_stream.turbo_progress_bar_show()`
+* `turbo_stream.turbo_progress_bar_hide()`
+* `turbo_stream.turbo_progress_bar_set_value(value)`
+
+
 ### Turbo Frame Actions
 
 * `turbo_stream.turbo_frame_reload(frame_id)`
 * `turbo_stream.turbo_frame_set_src(frame_id, src)`
 
 
-### Turbo Actions
-
-* `turbo_stream.redirect_to(url, turbo_action = nil, **attributes)`
-* `turbo_stream.turbo_clear_cache()`
 
 ## Previous Art
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -12,6 +12,7 @@ import * as History from "./actions/history"
 import * as Notification from "./actions/notification"
 import * as Storage from "./actions/storage"
 import * as Turbo from "./actions/turbo"
+import * as TurboProgressBar from "./actions/turbo_progress_bar"
 import * as TurboFrame from "./actions/turbo_frame"
 
 export * from "./actions/attributes"
@@ -26,6 +27,7 @@ export * from "./actions/history"
 export * from "./actions/notification"
 export * from "./actions/storage"
 export * from "./actions/turbo"
+export * from "./actions/turbo_progress_bar"
 export * from "./actions/turbo_frame"
 
 export function register(streamActions: TurboStreamActions) {
@@ -41,5 +43,6 @@ export function register(streamActions: TurboStreamActions) {
   Notification.registerNotificationActions(streamActions)
   Storage.registerStorageActions(streamActions)
   Turbo.registerTurboActions(streamActions)
+  TurboProgressBar.registerTurboProgressBarActions(streamActions)
   TurboFrame.registerTurboFrameActions(streamActions)
 }

--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -1,11 +1,17 @@
 import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 import * as Turbo from "@hotwired/turbo"
 import { Action } from "@hotwired/turbo/dist/types/core/types"
+import { BrowserAdapter } from "@hotwired/turbo/dist/types/core/native/browser_adapter"
+
 import Proxy from "../proxy"
 
 declare global {
   interface Window {
-    Turbo: typeof Turbo
+    Turbo: typeof Turbo & {
+      navigator: {
+        adapter: BrowserAdapter
+      }
+    }
   }
 }
 

--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -1,19 +1,6 @@
 import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
-import * as Turbo from "@hotwired/turbo"
 import { Action } from "@hotwired/turbo/dist/types/core/types"
-import { BrowserAdapter } from "@hotwired/turbo/dist/types/core/native/browser_adapter"
-
 import Proxy from "../proxy"
-
-declare global {
-  interface Window {
-    Turbo: typeof Turbo & {
-      navigator: {
-        adapter: BrowserAdapter
-      }
-    }
-  }
-}
 
 export function redirect_to(this: StreamElement) {
   const url = this.getAttribute("url") || "/"

--- a/src/actions/turbo_progress_bar.ts
+++ b/src/actions/turbo_progress_bar.ts
@@ -1,0 +1,21 @@
+import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+
+export function turbo_progress_bar_set_value(this: StreamElement) {
+  const value = this.getAttribute("value") || 0
+
+  window.Turbo.navigator.adapter.progressBar.setValue(Number(value))
+}
+
+export function turbo_progress_bar_show(this: StreamElement) {
+  window.Turbo.navigator.adapter.progressBar.show()
+}
+
+export function turbo_progress_bar_hide(this: StreamElement) {
+  window.Turbo.navigator.adapter.progressBar.hide()
+}
+
+export function registerTurboProgressBarActions(streamActions: TurboStreamActions) {
+  streamActions.turbo_progress_bar_set_value = turbo_progress_bar_set_value
+  streamActions.turbo_progress_bar_show = turbo_progress_bar_show
+  streamActions.turbo_progress_bar_hide = turbo_progress_bar_hide
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
+import * as Turbo from "@hotwired/turbo"
 import { TurboStreamAction, TurboStreamActions } from "@hotwired/turbo"
+import { BrowserAdapter } from "@hotwired/turbo/dist/types/core/native/browser_adapter"
 
 import * as TurboMorph from "turbo-morph"
 import * as Actions from "./actions"
@@ -6,6 +8,16 @@ import * as Utils from "./utils"
 
 export * as Actions from "./actions"
 export * as Utils from "./utils"
+
+declare global {
+  interface Window {
+    Turbo: typeof Turbo & {
+      navigator: {
+        adapter: BrowserAdapter
+      }
+    }
+  }
+}
 
 export function initialize(streamActions: TurboStreamActions) {
   TurboMorph.initialize(streamActions)

--- a/test/turbo_progress_bar/turbo_progress_bar_hide.test.js
+++ b/test/turbo_progress_bar/turbo_progress_bar_hide.test.js
@@ -1,0 +1,21 @@
+import sinon from "sinon"
+import { assert } from "@open-wc/testing"
+import { executeStream, registerAction } from "../test_helpers"
+
+registerAction("turbo_progress_bar_hide")
+
+describe("turbo_progress_bar_hide", () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it("defaults to 0", async () => {
+    const progressBar = { hide: sinon.fake() }
+    sinon.replace(window, "Turbo", { navigator: { adapter: { progressBar } } })
+
+    await executeStream(`<turbo-stream action="turbo_progress_bar_hide"></turbo-stream>`)
+
+    assert.equal(progressBar.hide.callCount, 1)
+    assert.deepEqual(progressBar.hide.args[0], [])
+  })
+})

--- a/test/turbo_progress_bar/turbo_progress_bar_set_value.test.js
+++ b/test/turbo_progress_bar/turbo_progress_bar_set_value.test.js
@@ -1,0 +1,51 @@
+import sinon from "sinon"
+import { assert } from "@open-wc/testing"
+import { executeStream, registerAction } from "../test_helpers"
+
+registerAction("turbo_progress_bar_set_value")
+
+describe("turbo_progress_bar_set_value", () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it("defaults to 0", async () => {
+    const progressBar = { setValue: sinon.fake() }
+    sinon.replace(window, "Turbo", { navigator: { adapter: { progressBar } } })
+
+    await executeStream(`<turbo-stream action="turbo_progress_bar_set_value"></turbo-stream>`)
+
+    assert.equal(progressBar.setValue.callCount, 1)
+    assert.deepEqual(progressBar.setValue.args[0], [0])
+  })
+
+  it("works with zero value", async () => {
+    const progressBar = { setValue: sinon.fake() }
+    sinon.replace(window, "Turbo", { navigator: { adapter: { progressBar } } })
+
+    await executeStream(`<turbo-stream action="turbo_progress_bar_set_value" value="0"></turbo-stream>`)
+
+    assert.equal(progressBar.setValue.callCount, 1)
+    assert.deepEqual(progressBar.setValue.args[0], [0])
+  })
+
+  it("works with integer values", async () => {
+    const progressBar = { setValue: sinon.fake() }
+    sinon.replace(window, "Turbo", { navigator: { adapter: { progressBar } } })
+
+    await executeStream(`<turbo-stream action="turbo_progress_bar_set_value" value="100"></turbo-stream>`)
+
+    assert.equal(progressBar.setValue.callCount, 1)
+    assert.deepEqual(progressBar.setValue.args[0], [100])
+  })
+
+  it("works with float values", async () => {
+    const progressBar = { setValue: sinon.fake() }
+    sinon.replace(window, "Turbo", { navigator: { adapter: { progressBar } } })
+
+    await executeStream(`<turbo-stream action="turbo_progress_bar_set_value" value="0.5"></turbo-stream>`)
+
+    assert.equal(progressBar.setValue.callCount, 1)
+    assert.deepEqual(progressBar.setValue.args[0], [0.5])
+  })
+})

--- a/test/turbo_progress_bar/turbo_progress_bar_show.test.js
+++ b/test/turbo_progress_bar/turbo_progress_bar_show.test.js
@@ -1,0 +1,21 @@
+import sinon from "sinon"
+import { assert } from "@open-wc/testing"
+import { executeStream, registerAction } from "../test_helpers"
+
+registerAction("turbo_progress_bar_show")
+
+describe("turbo_progress_bar_show", () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it("defaults to 0", async () => {
+    const progressBar = { show: sinon.fake() }
+    sinon.replace(window, "Turbo", { navigator: { adapter: { progressBar } } })
+
+    await executeStream(`<turbo-stream action="turbo_progress_bar_show"></turbo-stream>`)
+
+    assert.equal(progressBar.show.callCount, 1)
+    assert.deepEqual(progressBar.show.args[0], [])
+  })
+})


### PR DESCRIPTION
This pull request implements three new actions to control the Turbo Progress Bar:

* `turbo_stream.turbo_progress_bar_show()`
* `turbo_stream.turbo_progress_bar_hide()`
* `turbo_stream.turbo_progress_bar_set_value(value)`


Resolves #19 