### PR TITLE
Add `turbo_frame` option to `redirect_to` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Checkout the instructions in the [`turbo_power-rails`](https://github.com/marcor
 
 ### Turbo Actions
 
-* `turbo_stream.redirect_to(url, turbo_action = nil, **attributes)`
+* `turbo_stream.redirect_to(url, turbo_action = nil, turbo_frame: nil, **attributes)`
 * `turbo_stream.turbo_clear_cache()`
 
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Checkout the instructions in the [`turbo_power-rails`](https://github.com/marcor
 
 ### Turbo Actions
 
-* `turbo_stream.redirect_to(url, turbo_action = nil, turbo_frame: nil, **attributes)`
+* `turbo_stream.redirect_to(url, turbo_action = nil, frame: nil, **attributes)`
 * `turbo_stream.turbo_clear_cache()`
 
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Checkout the instructions in the [`turbo_power-rails`](https://github.com/marcor
 
 ### Turbo Actions
 
-* `turbo_stream.redirect_to(url, turbo_action = nil, frame: nil, **attributes)`
+* `turbo_stream.redirect_to(url, turbo_action = nil, turbo_frame = nil, **attributes)`
 * `turbo_stream.turbo_clear_cache()`
 
 

--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -8,16 +8,16 @@ export function redirect_to(this: StreamElement) {
   const turboAction = (this.getAttribute("turbo-action") || "advance") as Action
   const turboFrame = this.getAttribute("turbo-frame")
   const turbo = this.getAttribute("turbo") !== "false"
-  const args: Partial<VisitOptions> = {
+  const options: Partial<VisitOptions> = {
     action: turboAction,
   }
 
   if (turboFrame) {
-    args.frame = turboFrame
+    options.frame = turboFrame
   }
 
   if (turbo && window.Turbo) {
-    window.Turbo.visit(url, args)
+    window.Turbo.visit(url, options)
   } else {
     Proxy.location.assign(url)
   }

--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -5,11 +5,11 @@ import Proxy from "../proxy"
 export function redirect_to(this: StreamElement) {
   const url = this.getAttribute("url") || "/"
   const turboAction = (this.getAttribute("turbo-action") || "advance") as Action
-  const turboFrame = (this.getAttribute("turbo-frame")) as Action
+  const frame = (this.getAttribute("frame")) as Action
   const turbo = this.getAttribute("turbo") !== "false"
 
   if (turbo && window.Turbo) {
-    window.Turbo.visit(url, { action: turboAction, frame: turboFrame })
+    window.Turbo.visit(url, { action: turboAction, frame: frame })
   } else {
     Proxy.location.assign(url)
   }

--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -5,11 +5,11 @@ import Proxy from "../proxy"
 export function redirect_to(this: StreamElement) {
   const url = this.getAttribute("url") || "/"
   const turboAction = (this.getAttribute("turbo-action") || "advance") as Action
-  const frame = (this.getAttribute("frame")) as Action
+  const turboFrame = (this.getAttribute("turbo-frame")) as Action
   const turbo = this.getAttribute("turbo") !== "false"
 
   if (turbo && window.Turbo) {
-    window.Turbo.visit(url, { action: turboAction, frame: frame })
+    window.Turbo.visit(url, { action: turboAction, frame: turboFrame })
   } else {
     Proxy.location.assign(url)
   }

--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -5,10 +5,11 @@ import Proxy from "../proxy"
 export function redirect_to(this: StreamElement) {
   const url = this.getAttribute("url") || "/"
   const turboAction = (this.getAttribute("turbo-action") || "advance") as Action
+  const turboFrame = (this.getAttribute("turbo-frame")) as Action
   const turbo = this.getAttribute("turbo") !== "false"
 
   if (turbo && window.Turbo) {
-    window.Turbo.visit(url, { action: turboAction })
+    window.Turbo.visit(url, { action: turboAction, frame: turboFrame })
   } else {
     Proxy.location.assign(url)
   }

--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -1,5 +1,6 @@
 import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 import { Action } from "@hotwired/turbo/dist/types/core/types"
+import { VisitOptions } from "@hotwired/turbo/dist/types/core/drive/visit"
 import Proxy from "../proxy"
 
 export function redirect_to(this: StreamElement) {
@@ -7,7 +8,7 @@ export function redirect_to(this: StreamElement) {
   const turboAction = (this.getAttribute("turbo-action") || "advance") as Action
   const turboFrame = this.getAttribute("turbo-frame") as Action
   const turbo = this.getAttribute("turbo") !== "false"
-  const args: Partial<{ action: Action; frame?: string }> = {
+  const args: Partial<VisitOptions> = {
     action: turboAction,
   }
 

--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -5,11 +5,18 @@ import Proxy from "../proxy"
 export function redirect_to(this: StreamElement) {
   const url = this.getAttribute("url") || "/"
   const turboAction = (this.getAttribute("turbo-action") || "advance") as Action
-  const turboFrame = (this.getAttribute("turbo-frame")) as Action
+  const turboFrame = this.getAttribute("turbo-frame") as Action
   const turbo = this.getAttribute("turbo") !== "false"
+  const args: Partial<{ action: Action; frame?: string }> = {
+    action: turboAction,
+  }
+
+  if (turboFrame) {
+    args.frame = turboFrame
+  }
 
   if (turbo && window.Turbo) {
-    window.Turbo.visit(url, { action: turboAction, frame: turboFrame })
+    window.Turbo.visit(url, args)
   } else {
     Proxy.location.assign(url)
   }

--- a/test/turbo/redirect_to.test.js
+++ b/test/turbo/redirect_to.test.js
@@ -150,7 +150,9 @@ describe("redirect_to", () => {
     it("renders the frame attribute", async () => {
       sinon.replace(window, "Turbo", { visit: sinon.fake(), frame: "modals" })
 
-      await executeStream(`<turbo-stream action="redirect_to" turbo-frame="modals" url="http://localhost:8080"></turbo-stream>`)
+      await executeStream(
+        `<turbo-stream action="redirect_to" turbo-frame="modals" url="http://localhost:8080"></turbo-stream>`
+      )
 
       const expected = ["http://localhost:8080", { action: "advance", frame: "modals" }]
 

--- a/test/turbo/redirect_to.test.js
+++ b/test/turbo/redirect_to.test.js
@@ -145,4 +145,18 @@ describe("redirect_to", () => {
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
   })
+
+  context("turbo_frame attribute", () => {
+    it("renders the frame attribute", async () => {
+      sinon.replace(window, "Turbo", { visit: sinon.fake(), frame: "modals" })
+
+      await executeStream(`<turbo-stream action="redirect_to" frame="modals" url="http://localhost:8080"></turbo-stream>`)
+
+      const expected = ["http://localhost:8080", { action: "advance", frame: "modals" }]
+
+      assert.equal(Turbo.visit.callCount, 1)
+      assert.equal(TurboPowerLocation.assign.callCount, 0)
+      assert.deepEqual(Turbo.visit.args[0], expected)
+    })
+  })
 })

--- a/test/turbo/redirect_to.test.js
+++ b/test/turbo/redirect_to.test.js
@@ -148,7 +148,7 @@ describe("redirect_to", () => {
 
   context("turbo_frame attribute", () => {
     it("renders the frame attribute", async () => {
-      sinon.replace(window, "Turbo", { visit: sinon.fake(), frame: "modals" })
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
 
       await executeStream(
         `<turbo-stream action="redirect_to" turbo-frame="modals" url="http://localhost:8080"></turbo-stream>`


### PR DESCRIPTION
Adds the `frame` option to the `redirect_to` action.
Super useful for when you'd like to perform an update and a redirect using turbo streams.

I think the `frame` keyword argument is better suited for this rather than a positional argument, but it's up to you to set the API.

Thanks!

<img width="928" alt="CleanShot 2023-08-22 at 03 11 09@2x" src="https://github.com/marcoroth/turbo_power/assets/1334409/7fef66c4-07a5-4f57-8829-291822078169">
