### PR TITLE
Implement `replace_css_class` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Checkout the instructions in the [`turbo_power-rails`](https://github.com/marcor
 * `turbo_stream.set_styles(target, styles, **attributes)`
 * `turbo_stream.set_value(target, value, **attributes)`
 * `turbo_stream.toggle_css_class(target, classes, **attributes)`
+* `turbo_stream.replace_css_class(target, from, to, **attributes)`
 
 
 ### Event Actions

--- a/src/actions/attributes.ts
+++ b/src/actions/attributes.ts
@@ -102,6 +102,17 @@ export function toggle_css_class(this: StreamElement) {
   }
 }
 
+export function replace_css_class(this: StreamElement) {
+  const from = this.getAttribute("from") || ""
+  const to = this.getAttribute("to") || ""
+
+  if (from && to) {
+    this.targetElements.forEach((element: HTMLElement) => element.classList.replace(from, to))
+  } else {
+    console.warn(`[TurboPower] no "from" or "to" class provided for Turbo Streams operation "replace_css_class"`)
+  }
+}
+
 export function registerAttributesActions(streamActions: TurboStreamActions) {
   streamActions.add_css_class = add_css_class
   streamActions.remove_css_class = remove_css_class
@@ -113,4 +124,5 @@ export function registerAttributesActions(streamActions: TurboStreamActions) {
   streamActions.set_styles = set_styles
   streamActions.set_value = set_value
   streamActions.toggle_css_class = toggle_css_class
+  streamActions.replace_css_class = replace_css_class
 }

--- a/test/attributes/replace_css_class.test.js
+++ b/test/attributes/replace_css_class.test.js
@@ -1,0 +1,79 @@
+import sinon from "sinon"
+import { fixture, assert } from "@open-wc/testing"
+import { executeStream, registerAction } from "../test_helpers"
+
+registerAction("replace_css_class")
+
+describe("replace_css_class", () => {
+  context("warnings", () => {
+    afterEach(() => {
+      sinon.restore()
+    })
+    it('should do nothing and print warning if no "from" were provided', async () => {
+      sinon.replace(console, "warn", sinon.fake())
+
+      await fixture('<div id="element"></div>')
+
+      const expectedWarning =
+        '[TurboPower] no "from" or "to" class provided for Turbo Streams operation "replace_css_class"'
+
+      assert.equal(document.querySelector("#element").getAttribute("from"), null)
+      assert(!console.warn.calledWith(expectedWarning), `console.warn wasn't called with "${expectedWarning}"`)
+
+      await executeStream('<turbo-stream action="replace_css_class" classes="" target="element"></turbo-stream>')
+
+      assert.equal(document.querySelector("#element").getAttribute("from"), null)
+      assert(console.warn.calledWith(expectedWarning), `console.warn wasn't called with "${expectedWarning}"`)
+    })
+
+    it('should do nothing and print warning if "from" attribute is missing', async () => {
+      sinon.replace(console, "warn", sinon.fake())
+
+      await fixture('<div id="element"></div>')
+
+      const expectedWarning =
+        '[TurboPower] no "from" or "to" class provided for Turbo Streams operation "replace_css_class"'
+
+      assert.equal(document.querySelector("#element").getAttribute("from"), null)
+      assert(!console.warn.calledWith(expectedWarning), `console.warn wasn't called with "${expectedWarning}"`)
+
+      await executeStream('<turbo-stream action="replace_css_class" target="element"></turbo-stream>')
+
+      assert.equal(document.querySelector("#element").getAttribute("from"), null)
+      assert(console.warn.calledWith(expectedWarning), `console.warn wasn't called with "${expectedWarning}"`)
+    })
+  })
+
+  context("target", () => {
+    it("should replace the css class", async () => {
+      await fixture('<div id="element" class="background-blue"></div>')
+      assert.equal(document.querySelector("#element").getAttribute("class"), "background-blue")
+
+      await executeStream(
+        '<turbo-stream action="replace_css_class" from="background-blue" to="background-red" target="element"></turbo-stream>',
+      )
+      assert.equal(document.querySelector("#element").getAttribute("class"), "background-red")
+    })
+  })
+
+  context("targets", () => {
+    it("should replace the css class", async () => {
+      await fixture(`
+        <div id="one" class="background-blue"></div>
+        <div id="two" class="background-blue"></div>
+        <div id="three" class="background-blue"></div>
+      `)
+
+      assert.equal(document.querySelector("#one").getAttribute("class"), "background-blue")
+      assert.equal(document.querySelector("#two").getAttribute("class"), "background-blue")
+      assert.equal(document.querySelector("#three").getAttribute("class"), "background-blue")
+
+      await executeStream(
+        '<turbo-stream action="replace_css_class" from="background-blue" to="background-red" targets="div"></turbo-stream>',
+      )
+      assert.equal(document.querySelector("#one").getAttribute("class"), "background-red")
+      assert.equal(document.querySelector("#two").getAttribute("class"), "background-red")
+      assert.equal(document.querySelector("#three").getAttribute("class"), "background-red")
+    })
+  })
+})


### PR DESCRIPTION
This PR implements the `replace_css_class` action.

~~I ended up not using the suggested `replace()` function from the issue, because I didn't saw a way to use it with multiple classes.
The downside of my implementation is, it could change the order of the classes.   
But I think that shouldn't be a big problem, since the order of the classes shouldn't matter.~~       

closes #52