### PR TITLE
Fix template typo in dispatch event test

### DIFF
--- a/test/events/dispatch_event.test.js
+++ b/test/events/dispatch_event.test.js
@@ -87,7 +87,7 @@ describe("dispatch_event", () => {
 
       setTimeout(() =>
         executeStream(
-          '<turbo-stream action="dispatch_event" name="my:event" target="element"><tempalte>{}</template></turbo-stream>',
+          '<turbo-stream action="dispatch_event" name="my:event" target="element"><template>{}</template></turbo-stream>',
         ),
       )
 


### PR DESCRIPTION
Hi there, thanks for the repository. So many interesting patterns collected here.

While passing, I think the typo is actually sending it down the path of having no template -- rather than a template that happens to be empty.