### PR TITLE
Upgrade @hotwired/turbo to 8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ import * as Turbo from '@hotwired/turbo'
 +TurboPower.initialize(Turbo.StreamActions)
 ```
 
+> [!NOTE]
+> **TypeScript users:** `turbo_power`'s type declarations re-export types from `@hotwired/turbo`, which since Turbo 8 ships its types via the community-maintained [`@types/hotwired__turbo`](https://www.npmjs.com/package/@types/hotwired__turbo) package. It isn't a runtime dependency of `turbo_power`, so if you consume the types you'll want to install it yourself:
+>
+> ```bash
+> yarn add --dev @types/hotwired__turbo
+> ```
+
 ## Getting Started with Rails
 
 Checkout the instructions in the [`turbo_power-rails`](https://github.com/marcoroth/turbo_power-rails) repo.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-terser": "^0.4.0",
     "@rollup/plugin-typescript": "^12.1.0",
+    "@types/hotwired__turbo": "^8.0.14",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^6.18.0",
     "@web/test-runner": "^0.20.0",
@@ -45,9 +46,6 @@
     "tslib": "^2.6.2",
     "turbo-morph": "^0.2.0",
     "typescript": "^5.3.3"
-  },
-  "dependencies": {
-    "@types/hotwired__turbo": "^8.0.14"
   },
   "peerDependencies": {
     "@hotwired/turbo": ">= 8.0.0"

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "dev": "concurrently 'yarn run watch' 'yarn run start'",
     "clean": "rimraf dist",
     "prerelease": "yarn build",
+    "pretest": "yarn build",
     "test": "web-test-runner test/**/*.test.js",
     "lint": "eslint .",
     "format": "yarn lint --fix"
   },
   "devDependencies": {
-    "@hotwired/turbo": "^7.2.5",
+    "@hotwired/turbo": "^8.0.0",
     "@open-wc/testing": "^4.0.0",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-terser": "^0.4.0",
@@ -44,6 +45,9 @@
     "tslib": "^2.6.2",
     "turbo-morph": "^0.2.0",
     "typescript": "^5.3.3"
+  },
+  "dependencies": {
+    "@types/hotwired__turbo": "^8.0.14"
   },
   "peerDependencies": {
     "@hotwired/turbo": ">= 7.2"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "@types/hotwired__turbo": "^8.0.14"
   },
   "peerDependencies": {
-    "@hotwired/turbo": ">= 7.2"
+    "@hotwired/turbo": ">= 8.0.0"
   }
 }

--- a/playground/package.json
+++ b/playground/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "https://github.com/marcoroth/turbo_power",
   "dependencies": {
-    "@hotwired/turbo": "^7.2.4",
+    "@hotwired/turbo": "^8.0.0",
     "turbo_power": "link:../"
   },
   "scripts": {

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -117,10 +117,10 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz#acad351d582d157bb145535db2a6ff53dd514b5c"
   integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
 
-"@hotwired/turbo@^7.2.4":
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.2.4.tgz#0d35541be32cfae3b4f78c6ab9138f5b21f28a21"
-  integrity sha512-c3xlOroHp/cCZHDOuLp6uzQYEbvXBUVaal0puXoGJ9M8L/KHwZ3hQozD4dVeSN9msHWLxxtmPT1TlCN7gFhj4w==
+"@hotwired/turbo@^8.0.0":
+  version "8.0.23"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.23.tgz#a6eebc9ab4a5faadae265a4cbec8cfcb5731e77c"
+  integrity sha512-GZ7cijxEZ6Ig71u7rD6LHaRv/wcE/hNsc+nEfiWOkLNqUgLOwo5MNGWOy5ZV9ZUDSiQx1no7YxjTNnT4O6//cQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -746,7 +746,8 @@ to-regex-range@^5.0.1:
     is-number "^7.0.0"
 
 "turbo_power@link:..":
-  version "0.7.1"
+  version "0.0.0"
+  uid ""
 
 unpipe@~1.0.0:
   version "1.0.0"

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,4 +1,4 @@
-import { TurboStreamActions } from "@hotwired/turbo"
+import type { TurboStreamActions } from "@hotwired/turbo"
 
 import * as Attributes from "./actions/attributes"
 import * as Browser from "./actions/browser"

--- a/src/actions/attributes.ts
+++ b/src/actions/attributes.ts
@@ -56,7 +56,7 @@ export function toggle_attribute(this: StreamElement): void {
 
   const toggleForce: boolean | undefined = force === null ? undefined : force.toLowerCase() === "true"
 
-  this.targetElements.forEach((element: HTMLElement): void => {
+  this.targetElements.forEach((element: Element): void => {
     element.toggleAttribute(attribute, toggleForce)
   })
 }
@@ -66,7 +66,7 @@ export function set_dataset_attribute(this: StreamElement) {
   const value = this.getAttribute("value") || ""
 
   if (attribute) {
-    this.targetElements.forEach((element: HTMLElement) => (element.dataset[camelize(attribute)] = value))
+    this.targetElements.forEach((element: Element) => ((element as HTMLElement).dataset[camelize(attribute)] = value))
   } else {
     console.warn(`[TurboPower] no "attribute" provided for Turbo Streams operation "set_dataset_attribute"`)
   }
@@ -97,13 +97,13 @@ export function set_style(this: StreamElement) {
 export function set_styles(this: StreamElement) {
   const styles = this.getAttribute("styles") || ""
 
-  this.targetElements.forEach((element: HTMLElement) => element.setAttribute("style", styles))
+  this.targetElements.forEach((element: Element) => element.setAttribute("style", styles))
 }
 
 export function set_value(this: StreamElement) {
   const value = this.getAttribute("value") || ""
 
-  this.targetElements.forEach((element: HTMLInputElement) => (element.value = value))
+  this.targetElements.forEach((element: Element) => ((element as HTMLInputElement).value = value))
 }
 
 export function toggle_css_class(this: StreamElement) {
@@ -123,7 +123,7 @@ export function replace_css_class(this: StreamElement) {
   const to = this.getAttribute("to") || ""
 
   if (from && to) {
-    this.targetElements.forEach((element: HTMLElement) => {
+    this.targetElements.forEach((element: Element) => {
       const wasReplaced = element.classList.replace(from, to)
 
       if (!wasReplaced) {

--- a/src/actions/attributes.ts
+++ b/src/actions/attributes.ts
@@ -1,4 +1,4 @@
-import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+import type { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 
 import { camelize, typecast, tokenize } from "../utils"
 

--- a/src/actions/browser.ts
+++ b/src/actions/browser.ts
@@ -26,7 +26,7 @@ export function scroll_into_view(this: StreamElement) {
 }
 
 export function set_focus(this: StreamElement) {
-  this.targetElements.forEach((element: HTMLElement) => element.focus())
+  this.targetElements.forEach((element: Element) => (element as HTMLElement).focus())
 }
 
 export function set_title(this: StreamElement) {

--- a/src/actions/browser.ts
+++ b/src/actions/browser.ts
@@ -1,4 +1,4 @@
-import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+import type { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 
 export function reload(this: StreamElement) {
   window.location.reload()

--- a/src/actions/debug.ts
+++ b/src/actions/debug.ts
@@ -1,4 +1,4 @@
-import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+import type { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 
 // turbo_stream.console_log(message, level = :log)
 export function console_log(this: StreamElement) {

--- a/src/actions/deprecated.ts
+++ b/src/actions/deprecated.ts
@@ -1,4 +1,4 @@
-import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+import type { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 
 export function invoke(this: StreamElement) {
   console.warn(

--- a/src/actions/document.ts
+++ b/src/actions/document.ts
@@ -1,4 +1,4 @@
-import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+import type { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 import { CookieStringBuilder } from "./document/cookie_string_builder"
 
 export function set_cookie(this: StreamElement) {

--- a/src/actions/document/cookie_string_builder.ts
+++ b/src/actions/document/cookie_string_builder.ts
@@ -1,4 +1,4 @@
-import { StreamElement } from "@hotwired/turbo"
+import type { StreamElement } from "@hotwired/turbo"
 
 type MappingRow = [string, string, boolean]
 

--- a/src/actions/dom.ts
+++ b/src/actions/dom.ts
@@ -1,4 +1,4 @@
-import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+import type { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 
 export function graft(this: StreamElement) {
   const selector = this.getAttribute("parent")

--- a/src/actions/events.ts
+++ b/src/actions/events.ts
@@ -1,4 +1,4 @@
-import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+import type { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 
 export function dispatch_event(this: StreamElement) {
   const name = this.getAttribute("name")

--- a/src/actions/form.ts
+++ b/src/actions/form.ts
@@ -1,7 +1,7 @@
 import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 
 export function reset_form(this: StreamElement) {
-  this.targetElements.forEach((form: HTMLFormElement) => form.reset())
+  this.targetElements.forEach((form: Element) => (form as HTMLFormElement).reset())
 }
 
 export function registerFormActions(streamActions: TurboStreamActions) {

--- a/src/actions/form.ts
+++ b/src/actions/form.ts
@@ -1,4 +1,4 @@
-import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+import type { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 
 export function reset_form(this: StreamElement) {
   this.targetElements.forEach((form: Element) => (form as HTMLFormElement).reset())

--- a/src/actions/history.ts
+++ b/src/actions/history.ts
@@ -1,4 +1,4 @@
-import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+import type { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 
 export function push_state(this: StreamElement) {
   const url = this.getAttribute("url")

--- a/src/actions/notification.ts
+++ b/src/actions/notification.ts
@@ -1,4 +1,4 @@
-import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+import type { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 import { camelize, typecast } from "../utils"
 
 const PERMITTED_ATTRIBUTES = [

--- a/src/actions/storage.ts
+++ b/src/actions/storage.ts
@@ -1,4 +1,4 @@
-import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+import type { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 
 function storage(type: string | null): Storage {
   return type === "session" ? window.sessionStorage : window.localStorage

--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -1,6 +1,4 @@
-import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
-import { Action } from "@hotwired/turbo/dist/types/core/types"
-import { VisitOptions } from "@hotwired/turbo/dist/types/core/drive/visit"
+import { Action, StreamElement, TurboStreamActions, VisitOptions } from "@hotwired/turbo"
 import Proxy from "../proxy"
 
 export function redirect_to(this: StreamElement) {

--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -1,4 +1,4 @@
-import { Action, StreamElement, TurboStreamActions, VisitOptions } from "@hotwired/turbo"
+import type { Action, StreamElement, TurboStreamActions, VisitOptions } from "@hotwired/turbo"
 import Proxy from "../proxy"
 
 export function redirect_to(this: StreamElement) {

--- a/src/actions/turbo_frame.ts
+++ b/src/actions/turbo_frame.ts
@@ -1,4 +1,4 @@
-import { StreamElement, TurboStreamActions, FrameElement } from "@hotwired/turbo"
+import type { StreamElement, TurboStreamActions, FrameElement } from "@hotwired/turbo"
 
 export function turbo_frame_reload(this: StreamElement) {
   this.targetElements.forEach((element: Element) => (element as FrameElement).reload())

--- a/src/actions/turbo_frame.ts
+++ b/src/actions/turbo_frame.ts
@@ -1,12 +1,13 @@
 import { StreamElement, TurboStreamActions, FrameElement } from "@hotwired/turbo"
 
 export function turbo_frame_reload(this: StreamElement) {
-  this.targetElements.forEach((element: FrameElement) => element.reload())
+  this.targetElements.forEach((element: Element) => (element as FrameElement).reload())
 }
 
 export function turbo_frame_set_src(this: StreamElement) {
-  const src = this.getAttribute("src")
-  this.targetElements.forEach((element: FrameElement) => (element.src = src))
+  const src = this.getAttribute("src") || ""
+
+  this.targetElements.forEach((element: Element) => ((element as FrameElement).src = src))
 }
 
 export function registerTurboFrameActions(streamActions: TurboStreamActions) {

--- a/src/actions/turbo_progress_bar.ts
+++ b/src/actions/turbo_progress_bar.ts
@@ -1,4 +1,4 @@
-import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
+import type { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 
 export function turbo_progress_bar_set_value(this: StreamElement) {
   const value = this.getAttribute("value") || 0

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import * as Turbo from "@hotwired/turbo"
-import { BrowserAdapter, TurboStreamAction, TurboStreamActions } from "@hotwired/turbo"
+import type { BrowserAdapter, TurboStreamAction, TurboStreamActions } from "@hotwired/turbo"
 
 import * as TurboMorph from "turbo-morph"
 import * as Actions from "./actions"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import * as Turbo from "@hotwired/turbo"
-import { TurboStreamAction, TurboStreamActions } from "@hotwired/turbo"
-import { BrowserAdapter } from "@hotwired/turbo/dist/types/core/native/browser_adapter"
+import { BrowserAdapter, TurboStreamAction, TurboStreamActions } from "@hotwired/turbo"
 
 import * as TurboMorph from "turbo-morph"
 import * as Actions from "./actions"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "noUnusedLocals": true,
     "rootDir": "src",
     "strict": true,
+    "verbatimModuleSyntax": true,
     "target": "es2017",
     "removeComments": true,
     "outDir": "dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,10 +83,10 @@
   dependencies:
     "@types/chai" "^4.2.12"
 
-"@hotwired/turbo@^7.2.5":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.3.0.tgz#2226000fff1aabda9fd9587474565c9929dbf15d"
-  integrity sha512-Dcu+NaSvHLT7EjrDrkEmH4qET2ZJZ5IcCWmNXxNQTBwlnE5tBZfN6WxZ842n5cHV52DH/AKNirbPBtcEXDLW4g==
+"@hotwired/turbo@^8.0.0":
+  version "8.0.23"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.23.tgz#a6eebc9ab4a5faadae265a4cbec8cfcb5731e77c"
+  integrity sha512-GZ7cijxEZ6Ig71u7rD6LHaRv/wcE/hNsc+nEfiWOkLNqUgLOwo5MNGWOy5ZV9ZUDSiQx1no7YxjTNnT4O6//cQ==
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"
@@ -642,6 +642,11 @@
     "@types/express-serve-static-core" "^4.17.33"
     "@types/qs" "*"
     "@types/serve-static" "*"
+
+"@types/hotwired__turbo@^8.0.14":
+  version "8.0.14"
+  resolved "https://registry.yarnpkg.com/@types/hotwired__turbo/-/hotwired__turbo-8.0.14.tgz#870466365d9e77971005c7baab8c5f3e6576256e"
+  integrity sha512-XcbiK6iqSFdJc3sYrl9hjwuxVpw1SkB1stiif/6M1vMMJo2cqmTDiHYMc8ap+tc/GgXpAtEhJ3mwmE2ozht4iQ==
 
 "@types/http-assert@*":
   version "1.5.5"


### PR DESCRIPTION
## What

Upgrades `@hotwired/turbo` from 7.x to 8.x. Supersedes the stalled #162.

## Why

Turbo 8 [removed its bundled TypeScript declarations](https://github.com/hotwired/turbo/pull/971), so the old deep imports from `@hotwired/turbo/dist/types/*` no longer resolve and a bare bump fails `tsc`. The community-maintained [`@types/hotwired__turbo`](https://www.npmjs.com/package/@types/hotwired__turbo) now ships everything TurboPower needs as of `8.0.12` ([DefinitelyTyped#75152](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/75152)).

## Changes

- Bump `@hotwired/turbo` to `^8.0.0` (root + playground)
- Add `@types/hotwired__turbo` (`^8.0.14`) as a `dependency` — the generated `.d.ts` re-export Turbo's types, so consumers must be able to resolve them (mirrors marcoroth/turbo-morph#8)
- Replace deep type imports with top-level `@hotwired/turbo` `import type`s, and enable `verbatimModuleSyntax`
- `StreamElement.targetElements` is now `Element[]` (was `any[]`); widen/cast `forEach` callbacks accordingly
- Bump `peerDependencies."@hotwired/turbo"` to `>= 8.0.0` — the emitted `.d.ts` import `BrowserAdapter`, which only exists in Turbo 8's type surface
- Handle `null` from `getAttribute("src")` in `turbo_frame_set_src`
- Add a `pretest` hook so `yarn test` builds `dist/` first (matches CI)

## Verification

`yarn build` ✓ · `yarn test` — 202 passing ✓ · `yarn lint` ✓