### PR TITLE
Allow registering only specific action groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ import * as Turbo from '@hotwired/turbo'
 +TurboPower.initialize(Turbo.StreamActions)
 ```
 
+### Registering only specific actions
+
+By default `initialize` registers every action. If you only need a subset, pass an array of action groups as the second argument and only those groups will be registered (the `morph` action is always registered regardless — see below):
+
+```js
+// application.js
+import * as Turbo from '@hotwired/turbo'
+
+import TurboPower, { AttributeActions, BrowserActions } from 'turbo_power'
+
+TurboPower.initialize(Turbo.StreamActions, [AttributeActions, BrowserActions])
+```
+
+The available action groups are:
+
+`AttributeActions`, `BrowserActions`, `DebugActions`, `DeprecatedActions` (deprecated), `DocumentActions`, `DOMActions`, `EventActions`, `FormActions`, `HistoryActions`, `NotificationActions`, `StorageActions`, `TurboActions`, `TurboProgressBarActions` and `TurboFrameActions`.
+
+The `morph` action from [`turbo-morph`](https://github.com/marcoroth/turbo-morph) is always registered, regardless of which action groups you pass.
+
 ## Getting Started with Rails
 
 Checkout the instructions in the [`turbo_power-rails`](https://github.com/marcoroth/turbo_power-rails) repo.

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -30,19 +30,46 @@ export * from "./actions/turbo"
 export * from "./actions/turbo_progress_bar"
 export * from "./actions/turbo_frame"
 
-export function register(streamActions: TurboStreamActions) {
-  Attributes.registerAttributesActions(streamActions)
-  Browser.registerBrowserActions(streamActions)
-  Debug.registerDebugActions(streamActions)
-  Deprecated.registerDeprecatedActions(streamActions)
-  Document.registerDocumentActions(streamActions)
-  DOM.registerDOMActions(streamActions)
-  Events.registerEventsActions(streamActions)
-  Form.registerFormActions(streamActions)
-  History.registerHistoryActions(streamActions)
-  Notification.registerNotificationActions(streamActions)
-  Storage.registerStorageActions(streamActions)
-  Turbo.registerTurboActions(streamActions)
-  TurboProgressBar.registerTurboProgressBarActions(streamActions)
-  TurboFrame.registerTurboFrameActions(streamActions)
+export interface ActionGroup {
+  register(streamActions: TurboStreamActions): void
+}
+
+export const ActionGroups = {
+  AttributeActions: { register: Attributes.registerAttributesActions },
+  BrowserActions: { register: Browser.registerBrowserActions },
+  DebugActions: { register: Debug.registerDebugActions },
+  DeprecatedActions: { register: Deprecated.registerDeprecatedActions },
+  DocumentActions: { register: Document.registerDocumentActions },
+  DOMActions: { register: DOM.registerDOMActions },
+  EventActions: { register: Events.registerEventsActions },
+  FormActions: { register: Form.registerFormActions },
+  HistoryActions: { register: History.registerHistoryActions },
+  NotificationActions: { register: Notification.registerNotificationActions },
+  StorageActions: { register: Storage.registerStorageActions },
+  TurboActions: { register: Turbo.registerTurboActions },
+  TurboProgressBarActions: { register: TurboProgressBar.registerTurboProgressBarActions },
+  TurboFrameActions: { register: TurboFrame.registerTurboFrameActions },
+} satisfies Record<string, ActionGroup>
+
+export const {
+  AttributeActions,
+  BrowserActions,
+  DebugActions,
+  DeprecatedActions,
+  DocumentActions,
+  DOMActions,
+  EventActions,
+  FormActions,
+  HistoryActions,
+  NotificationActions,
+  StorageActions,
+  TurboActions,
+  TurboProgressBarActions,
+  TurboFrameActions,
+} = ActionGroups
+
+export const allActionGroups: readonly ActionGroup[] = Object.freeze(Object.values(ActionGroups))
+
+export function register(streamActions: TurboStreamActions, actionGroups: readonly ActionGroup[] = allActionGroups) {
+  actionGroups.forEach((group) => group.register(streamActions))
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,30 @@ import { BrowserAdapter } from "@hotwired/turbo/dist/types/core/native/browser_a
 import * as TurboMorph from "turbo-morph"
 import * as Actions from "./actions"
 import * as Utils from "./utils"
+import type { ActionGroup } from "./actions"
 
 export * as Actions from "./actions"
 export * as Utils from "./utils"
+
+export {
+  ActionGroups,
+  allActionGroups,
+  AttributeActions,
+  BrowserActions,
+  DebugActions,
+  DeprecatedActions,
+  DocumentActions,
+  DOMActions,
+  EventActions,
+  FormActions,
+  HistoryActions,
+  NotificationActions,
+  StorageActions,
+  TurboActions,
+  TurboProgressBarActions,
+  TurboFrameActions,
+} from "./actions"
+export type { ActionGroup } from "./actions"
 
 declare global {
   interface Window {
@@ -19,9 +40,9 @@ declare global {
   }
 }
 
-export function initialize(streamActions: TurboStreamActions) {
+export function initialize(streamActions: TurboStreamActions, actionGroups?: readonly ActionGroup[]) {
   TurboMorph.initialize(streamActions)
-  Actions.register(streamActions)
+  Actions.register(streamActions, actionGroups)
 }
 
 export function register(name: string, action: TurboStreamAction, streamActions: TurboStreamActions) {
@@ -33,4 +54,7 @@ export default {
   register,
   Actions,
   Utils,
+  ActionGroups: Actions.ActionGroups,
+  allActionGroups: Actions.allActionGroups,
+  ...Actions.ActionGroups,
 }

--- a/test/initialize/initialize.test.js
+++ b/test/initialize/initialize.test.js
@@ -1,0 +1,126 @@
+import { assert } from "@open-wc/testing"
+import TurboPower, { ActionGroups, allActionGroups, AttributeActions, BrowserActions } from "../../"
+
+const ALL_GROUP_NAMES = [
+  "AttributeActions",
+  "BrowserActions",
+  "DebugActions",
+  "DeprecatedActions",
+  "DocumentActions",
+  "DOMActions",
+  "EventActions",
+  "FormActions",
+  "HistoryActions",
+  "NotificationActions",
+  "StorageActions",
+  "TurboActions",
+  "TurboProgressBarActions",
+  "TurboFrameActions",
+]
+
+describe("initialize", () => {
+  it("registers all action groups when none are specified", () => {
+    const streamActions = {}
+
+    TurboPower.initialize(streamActions)
+
+    assert.isFunction(streamActions.add_css_class, "attribute action")
+    assert.isFunction(streamActions.reload, "browser action")
+    assert.isFunction(streamActions.console_log, "debug action")
+    assert.isFunction(streamActions.dispatch_event, "event action")
+    assert.isFunction(streamActions.notification, "notification action")
+    assert.isFunction(streamActions.morph, "morph action")
+  })
+
+  it("registers only the provided action groups", () => {
+    const streamActions = {}
+
+    TurboPower.initialize(streamActions, [AttributeActions, BrowserActions])
+
+    assert.isFunction(streamActions.add_css_class, "attribute action is registered")
+    assert.isFunction(streamActions.reload, "browser action is registered")
+
+    assert.isUndefined(streamActions.console_log, "debug action is not registered")
+    assert.isUndefined(streamActions.dispatch_event, "event action is not registered")
+    assert.isUndefined(streamActions.notification, "notification action is not registered")
+  })
+
+  it("registers no action groups when an empty array is provided", () => {
+    const streamActions = {}
+
+    TurboPower.initialize(streamActions, [])
+
+    assert.isUndefined(streamActions.add_css_class)
+    assert.isUndefined(streamActions.reload)
+
+    // morph is always registered via turbo-morph
+    assert.isFunction(streamActions.morph)
+  })
+})
+
+describe("Actions.register", () => {
+  it("can be called directly with a subset of action groups", () => {
+    const streamActions = {}
+
+    TurboPower.Actions.register(streamActions, [AttributeActions])
+
+    assert.isFunction(streamActions.add_css_class, "attribute action is registered")
+    assert.isUndefined(streamActions.reload, "browser action is not registered")
+  })
+})
+
+describe("each action group registers its own actions", () => {
+  // One representative action per group. Guards against a group being wired
+  // to the wrong register function (a mis-mapping would otherwise pass).
+  const REPRESENTATIVE_ACTIONS = {
+    AttributeActions: "add_css_class",
+    BrowserActions: "reload",
+    DebugActions: "console_log",
+    DeprecatedActions: "invoke",
+    DocumentActions: "set_cookie",
+    DOMActions: "graft",
+    EventActions: "dispatch_event",
+    FormActions: "reset_form",
+    HistoryActions: "push_state",
+    NotificationActions: "notification",
+    StorageActions: "clear_storage",
+    TurboActions: "redirect_to",
+    TurboProgressBarActions: "turbo_progress_bar_set_value",
+    TurboFrameActions: "turbo_frame_reload",
+  }
+
+  Object.entries(REPRESENTATIVE_ACTIONS).forEach(([groupName, actionName]) => {
+    it(`${groupName} registers ${actionName}`, () => {
+      const streamActions = {}
+
+      TurboPower.Actions.register(streamActions, [ActionGroups[groupName]])
+
+      assert.isFunction(streamActions[actionName], `${groupName} registers ${actionName}`)
+    })
+  })
+})
+
+describe("action group exports", () => {
+  it("exposes every action group on the default export", () => {
+    ALL_GROUP_NAMES.forEach((name) => {
+      assert.isObject(TurboPower[name], `${name} is on the default export`)
+      assert.isFunction(TurboPower[name].register, `${name}.register is a function`)
+    })
+  })
+
+  it("keeps named exports identical to the default export members", () => {
+    assert.strictEqual(TurboPower.AttributeActions, AttributeActions)
+    assert.strictEqual(TurboPower.BrowserActions, BrowserActions)
+  })
+
+  it("includes every action group in allActionGroups", () => {
+    assert.strictEqual(allActionGroups.length, ALL_GROUP_NAMES.length)
+    ALL_GROUP_NAMES.forEach((name) => {
+      assert.include(allActionGroups, ActionGroups[name], `allActionGroups includes ${name}`)
+    })
+  })
+
+  it("exposes the same allActionGroups on the default export", () => {
+    assert.strictEqual(TurboPower.allActionGroups, allActionGroups)
+  })
+})


### PR DESCRIPTION
Closes #20

> [!WARNING]
> This PR branches off `main` (Turbo 7.x) and only touches the action-registration layer (`src/actions.ts`, `src/index.ts`), so it's orthogonal to #332 (_Upgrade @hotwired/turbo to 8.x_). The two don't conflict logically, but whichever lands second will need a trivial rebase. No behavioural interaction is expected — happy to rebase on top of #332 if you'd prefer to merge that first.

## What

Adds an optional second argument to `TurboPower.initialize()` (and `Actions.register()`) so consumers can enable a subset of actions instead of all-or-nothing:

```js
import * as Turbo from '@hotwired/turbo'
import TurboPower, { AttributeActions, BrowserActions } from 'turbo_power'

TurboPower.initialize(Turbo.StreamActions, [AttributeActions, BrowserActions])
```

This matches the API proposed in #20 verbatim.

## Why

This would help us cleanup our Turbo setup in a downstream project: https://github.com/opf/openproject/blob/dev/frontend/src/turbo/setup.ts#L59

## How

- Adds an `ActionGroup` interface (`{ register(streamActions): void }`).
- Defines all groups once in a single `ActionGroups` record. The named consts (`AttributeActions`, `BrowserActions`, …), the `allActionGroups` array, and the default-export members are all **derived** from that record — adding a new action group only requires one edit.
- `register(streamActions, actionGroups = allActionGroups)` iterates the groups. With no argument, every group registers as before, so existing callers are unaffected.
- `allActionGroups` is frozen and typed `readonly`, so consumer mutation can't corrupt the default used by `register`.
- `morph` (from `turbo-morph`) is always registered regardless of which groups are passed.
- Re-exports the named groups, `allActionGroups`, `ActionGroups`, and the `ActionGroup` type, and mirrors them all on the default export for UMD consumers.
- README section documenting the new usage.

## Tests

New `test/initialize/initialize.test.js` covering: all-groups default, subset, empty array (morph still registered), direct `Actions.register` with a subset, a table-driven smoke test that registers each group on its own and asserts a representative action (guards against a mis-wired mapping), every group present on the default export, named exports identical to default-export members, and an `allActionGroups` count guard against list drift.

Full suite: **224 passing**.

## Note for review

The friendly group names drop the plural the internal registrars use (`AttributeActions` → `registerAttributesActions`, `EventActions` → `registerEventsActions`). They're self-consistent and match the spelling in #20, but since these become permanent public API, happy to adjust the naming if you'd prefer a different convention.

## Credit

Based on the original implementation by @klaustopher in opf/turbo_power#1 (credited as co-author on the commit).
