### PR TITLE
Add `input_select` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Checkout the doc of the [`django-turbo-helper`](https://github.com/rails-inspire
 ### Form Actions
 
 * `turbo_stream.reset_form(target, **attributes)`
+* `turbo_stream.input_select(target, **attributes)`
 
 
 ### Storage Actions

--- a/src/actions/form.ts
+++ b/src/actions/form.ts
@@ -4,6 +4,11 @@ export function reset_form(this: StreamElement) {
   this.targetElements.forEach((form: HTMLFormElement) => form.reset())
 }
 
+export function input_select(this: StreamElement) {
+  this.targetElements.forEach((input: HTMLInputElement) => input.select())
+}
+
 export function registerFormActions(streamActions: TurboStreamActions) {
   streamActions.reset_form = reset_form
+  streamActions.input_select = input_select
 }

--- a/test/form/input_select.test.js
+++ b/test/form/input_select.test.js
@@ -1,0 +1,40 @@
+import { html, fixture, assert } from "@open-wc/testing"
+import { executeStream, registerAction } from "../test_helpers"
+
+registerAction("input_select")
+
+describe("input_select", () => {
+  context("target", () => {
+    it("should select the input text", async () => {
+      await fixture(html` <input id="input" value="Hello World" /> `)
+
+      const input = document.querySelector("#input")
+
+      assert.equal(input.selectionStart, input.selectionEnd)
+
+      await executeStream('<turbo-stream action="input_select" target="input"></turbo-stream>')
+
+      assert.equal(input.selectionStart, 0)
+      assert.equal(input.selectionEnd, input.value.length)
+    })
+  })
+
+  context("targets", () => {
+    it("should select the text of multiple inputs", async () => {
+      await fixture(html`
+        <input class="input" id="input1" value="First" />
+        <input class="input" id="input2" value="Second" />
+      `)
+
+      const input1 = document.querySelector("#input1")
+      const input2 = document.querySelector("#input2")
+
+      await executeStream('<turbo-stream action="input_select" targets=".input"></turbo-stream>')
+
+      assert.equal(input1.selectionStart, 0)
+      assert.equal(input1.selectionEnd, input1.value.length)
+      assert.equal(input2.selectionStart, 0)
+      assert.equal(input2.selectionEnd, input2.value.length)
+    })
+  })
+})


### PR DESCRIPTION
Implements the `input_select` action, which selects the text of target input elements via `input.select()`.

```html
<turbo-stream action="input_select" target="item_1"></turbo-stream>
```

- Added `input_select` to `src/actions/form.ts` and registered it.
- Added `test/form/input_select.test.js` (target + targets cases).
- Documented under Form Actions in the README.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)