### PR TITLE
Add `turbo_visit` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Checkout the doc of the [`django-turbo-helper`](https://github.com/rails-inspire
 ### Turbo Actions
 
 * `turbo_stream.redirect_to(url, turbo_action = nil, turbo_frame = nil, **attributes)`
-* `turbo_stream.turbo_visit(location, turbo_action = "advance", **attributes)`
+* `turbo_stream.turbo_visit(location, turbo_action = "advance", turbo_frame = nil, **attributes)`
 * `turbo_stream.turbo_clear_cache()`
 
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Checkout the doc of the [`django-turbo-helper`](https://github.com/rails-inspire
 ### Turbo Actions
 
 * `turbo_stream.redirect_to(url, turbo_action = nil, turbo_frame = nil, **attributes)`
+* `turbo_stream.turbo_visit(location, turbo_action = "advance", **attributes)`
 * `turbo_stream.turbo_clear_cache()`
 
 

--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -23,11 +23,22 @@ export function redirect_to(this: StreamElement) {
   }
 }
 
+export function turbo_visit(this: StreamElement) {
+  const location = this.getAttribute("location") || "/"
+  const turboAction = (this.getAttribute("turbo-action") || "advance") as Action
+  const options: Partial<VisitOptions> = {
+    action: turboAction,
+  }
+
+  window.Turbo.visit(location, options)
+}
+
 export function turbo_clear_cache() {
   window.Turbo.cache.clear()
 }
 
 export function registerTurboActions(streamActions: TurboStreamActions) {
   streamActions.redirect_to = redirect_to
+  streamActions.turbo_visit = turbo_visit
   streamActions.turbo_clear_cache = turbo_clear_cache
 }

--- a/src/actions/turbo.ts
+++ b/src/actions/turbo.ts
@@ -26,8 +26,13 @@ export function redirect_to(this: StreamElement) {
 export function turbo_visit(this: StreamElement) {
   const location = this.getAttribute("location") || "/"
   const turboAction = (this.getAttribute("turbo-action") || "advance") as Action
+  const turboFrame = this.getAttribute("turbo-frame")
   const options: Partial<VisitOptions> = {
     action: turboAction,
+  }
+
+  if (turboFrame) {
+    options.frame = turboFrame
   }
 
   window.Turbo.visit(location, options)

--- a/test/turbo/turbo_visit.test.js
+++ b/test/turbo/turbo_visit.test.js
@@ -42,6 +42,17 @@ describe("turbo_visit", () => {
       assert.equal(Turbo.visit.callCount, 1)
       assert.deepEqual(Turbo.visit.args[0], expected)
     })
+
+    it("uses / as fallback with location attribute without value", async () => {
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(`<turbo-stream action="turbo_visit" location></turbo-stream>`)
+
+      const expected = ["/", { action: "advance" }]
+
+      assert.equal(Turbo.visit.callCount, 1)
+      assert.deepEqual(Turbo.visit.args[0], expected)
+    })
   })
 
   context("turbo_action attribute", () => {
@@ -71,6 +82,18 @@ describe("turbo_visit", () => {
       )
 
       assert.deepEqual(Turbo.visit.args[0], ["/somewhere", { action: "restore" }])
+    })
+  })
+
+  context("turbo_frame attribute", () => {
+    it("passes the frame option", async () => {
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(
+        `<turbo-stream action="turbo_visit" location="/somewhere" turbo-frame="modals"></turbo-stream>`,
+      )
+
+      assert.deepEqual(Turbo.visit.args[0], ["/somewhere", { action: "advance", frame: "modals" }])
     })
   })
 })

--- a/test/turbo/turbo_visit.test.js
+++ b/test/turbo/turbo_visit.test.js
@@ -1,0 +1,76 @@
+import sinon from "sinon"
+import { assert } from "@open-wc/testing"
+import { executeStream, registerAction } from "../test_helpers"
+
+registerAction("turbo_visit")
+
+describe("turbo_visit", () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  context("location attribute", () => {
+    it("visits the provided location", async () => {
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(`<turbo-stream action="turbo_visit" location="/path/to/somewhere"></turbo-stream>`)
+
+      const expected = ["/path/to/somewhere", { action: "advance" }]
+
+      assert.equal(Turbo.visit.callCount, 1)
+      assert.deepEqual(Turbo.visit.args[0], expected)
+    })
+
+    it("uses / as fallback", async () => {
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(`<turbo-stream action="turbo_visit"></turbo-stream>`)
+
+      const expected = ["/", { action: "advance" }]
+
+      assert.equal(Turbo.visit.callCount, 1)
+      assert.deepEqual(Turbo.visit.args[0], expected)
+    })
+
+    it("uses / as fallback with empty location attribute", async () => {
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(`<turbo-stream action="turbo_visit" location=""></turbo-stream>`)
+
+      const expected = ["/", { action: "advance" }]
+
+      assert.equal(Turbo.visit.callCount, 1)
+      assert.deepEqual(Turbo.visit.args[0], expected)
+    })
+  })
+
+  context("turbo_action attribute", () => {
+    it("uses advance by default", async () => {
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(`<turbo-stream action="turbo_visit" location="/somewhere"></turbo-stream>`)
+
+      assert.deepEqual(Turbo.visit.args[0], ["/somewhere", { action: "advance" }])
+    })
+
+    it("uses replace", async () => {
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(
+        `<turbo-stream action="turbo_visit" location="/somewhere" turbo-action="replace"></turbo-stream>`,
+      )
+
+      assert.deepEqual(Turbo.visit.args[0], ["/somewhere", { action: "replace" }])
+    })
+
+    it("uses restore", async () => {
+      sinon.replace(window, "Turbo", { visit: sinon.fake() })
+
+      await executeStream(
+        `<turbo-stream action="turbo_visit" location="/somewhere" turbo-action="restore"></turbo-stream>`,
+      )
+
+      assert.deepEqual(Turbo.visit.args[0], ["/somewhere", { action: "restore" }])
+    })
+  })
+})


### PR DESCRIPTION
Implements the `turbo_visit` action, which navigates via `Turbo.visit(location, { action, frame })`.

```html
<turbo-stream action="turbo_visit" location="/somewhere" turbo-action="replace"></turbo-stream>
<turbo-stream action="turbo_visit" location="/somewhere" turbo-frame="modals"></turbo-stream>
```

- Added `turbo_visit` to `src/actions/turbo.ts` and registered it.
- `location` attribute (default `/`), `turbo-action` attribute (default `advance`), `turbo-frame` attribute (mapped to `Turbo.visit`'s `frame` option, mirroring `redirect_to`).
- Added `test/turbo/turbo_visit.test.js` — `location` fallbacks (including the bare attribute), `turbo-action` values, and `turbo-frame`.
- Documented under Turbo Actions in the README: `turbo_visit(location, turbo_action = "advance", turbo_frame = nil, **attributes)`.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)