### PR TITLE
Add `prevent_unload`/`allow_unload` actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Checkout the doc of the [`django-turbo-helper`](https://github.com/rails-inspire
   * `turbo_stream.scroll_into_view(targets, behavior:,  block:, inline:)`
 * `turbo_stream.set_focus(target, **attributes)`
 * `turbo_stream.set_title(title, **attributes)`
+* `turbo_stream.prevent_unload(**attributes)`
+* `turbo_stream.allow_unload(**attributes)`
 
 
 ### Document Actions

--- a/src/actions/browser.ts
+++ b/src/actions/browser.ts
@@ -41,9 +41,24 @@ export function set_title(this: StreamElement) {
   titleElement.textContent = title
 }
 
+function beforeUnloadHandler(event: BeforeUnloadEvent) {
+  event.preventDefault()
+  event.returnValue = "" // some browsers require returnValue set to show the prompt
+}
+
+export function prevent_unload(this: StreamElement) {
+  window.addEventListener("beforeunload", beforeUnloadHandler)
+}
+
+export function allow_unload(this: StreamElement) {
+  window.removeEventListener("beforeunload", beforeUnloadHandler)
+}
+
 export function registerBrowserActions(streamActions: TurboStreamActions) {
   streamActions.reload = reload
   streamActions.scroll_into_view = scroll_into_view
   streamActions.set_focus = set_focus
   streamActions.set_title = set_title
+  streamActions.prevent_unload = prevent_unload
+  streamActions.allow_unload = allow_unload
 }

--- a/test/browser/before_unload.test.js
+++ b/test/browser/before_unload.test.js
@@ -1,0 +1,49 @@
+import { assert } from "@open-wc/testing"
+import { executeStream, registerAction } from "../test_helpers"
+
+registerAction("prevent_unload")
+registerAction("allow_unload")
+
+function dispatchBeforeUnload() {
+  const event = new Event("beforeunload", { cancelable: true })
+  window.dispatchEvent(event)
+  return event
+}
+
+describe("before_unload", () => {
+  afterEach(async () => {
+    // always disarm so an armed guard never leaks into other tests
+    await executeStream('<turbo-stream action="allow_unload"></turbo-stream>')
+  })
+
+  context("prevent_unload", () => {
+    it("arms the beforeunload guard", async () => {
+      await executeStream('<turbo-stream action="prevent_unload"></turbo-stream>')
+
+      const event = dispatchBeforeUnload()
+
+      assert.isTrue(event.defaultPrevented)
+    })
+  })
+
+  context("allow_unload", () => {
+    it("disarms the beforeunload guard", async () => {
+      await executeStream('<turbo-stream action="prevent_unload"></turbo-stream>')
+      await executeStream('<turbo-stream action="allow_unload"></turbo-stream>')
+
+      const event = dispatchBeforeUnload()
+
+      assert.isFalse(event.defaultPrevented)
+    })
+
+    it("fully removes the guard even after repeated prevent_unload", async () => {
+      await executeStream('<turbo-stream action="prevent_unload"></turbo-stream>')
+      await executeStream('<turbo-stream action="prevent_unload"></turbo-stream>')
+      await executeStream('<turbo-stream action="allow_unload"></turbo-stream>')
+
+      const event = dispatchBeforeUnload()
+
+      assert.isFalse(event.defaultPrevented)
+    })
+  })
+})


### PR DESCRIPTION
Implements two Browser actions to arm and disarm a `beforeunload` guard, so the server can warn the user before they leave a tab with unsaved changes.

```html
<turbo-stream action="prevent_unload"></turbo-stream>
<turbo-stream action="allow_unload"></turbo-stream>
```

### Approach

- Uses `addEventListener("beforeunload", …)` with a single module-level named handler, **not** the `window.onbeforeunload` property. This composes with any other `beforeunload` listeners and removes only its own handler — assigning the property would clobber (and be clobbered by) other scripts.
- The handler calls `preventDefault()` (the modern trigger) and sets `returnValue` for broader browser support. No browser supported by Turbo 7.2+ displays the `returnValue` string, so the generic confirmation dialog is shown.
- `prevent_unload` is idempotent (re-adding the same handler reference is a no-op).
- No custom message attribute: modern browsers ignore custom `onbeforeunload` strings and show a generic dialog.

### Changes

- Added `prevent_unload` / `allow_unload` to `src/actions/browser.ts` and registered them.
- Added `test/browser/before_unload.test.js` — arm, disarm, and idempotency cases (asserts `event.defaultPrevented`).
- Documented both under Browser Actions in the README.

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)