### PR TITLE
Register `history_forward` action

### DIFF
--- a/src/actions/history.ts
+++ b/src/actions/history.ts
@@ -33,5 +33,6 @@ export function registerHistoryActions(streamActions: TurboStreamActions) {
   streamActions.push_state = push_state
   streamActions.replace_state = replace_state
   streamActions.history_back = history_back
+  streamActions.history_forward = history_forward
   streamActions.history_go = history_go
 }

--- a/test/history/register.test.js
+++ b/test/history/register.test.js
@@ -1,0 +1,15 @@
+import { assert } from "@open-wc/testing"
+import TurboPower from "../../"
+
+describe("registerHistoryActions", () => {
+  it("registers all history actions", () => {
+    const streamActions = {}
+    const actionNames = ["push_state", "replace_state", "history_back", "history_forward", "history_go"]
+
+    TurboPower.Actions.registerHistoryActions(streamActions)
+
+    actionNames.forEach((name) => {
+      assert.typeOf(streamActions[name], "function", `${name} not registered`)
+    })
+  })
+})


### PR DESCRIPTION
`history_forward` was defined and exported in `src/actions/history.ts` but missing from `registerHistoryActions`, so the action never reached Turbo Streams in a real app.

The existing `history_forward.test.js` passed regardless because the test helper registers each action by name from the `Actions` namespace and never exercises `registerHistoryActions`. Added `test/history/register.test.js` to cover the real registrar — it fails before this fix and passes after.

Closes #337