### PR TITLE
Make `push_state` / `replace_state` update Turbo's history

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Checkout the doc of the [`django-turbo-helper`](https://github.com/rails-inspire
 * `turbo_stream.history_back(**attributes)`
 * `turbo_stream.history_forward(**attributes)`
 * `turbo_stream.history_go(delta, **attributes)`
-* `turbo_stream.push_state(url, title = nil, state = nil, **attributes)`
-* `turbo_stream.replace_state(url, title = nil, state = nil, **attributes)`
+* `turbo_stream.push_state(url, **attributes)`
+* `turbo_stream.replace_state(url, **attributes)`
 
 
 ### Debug Actions

--- a/src/actions/history.ts
+++ b/src/actions/history.ts
@@ -10,10 +10,9 @@ export function push_state(this: StreamElement) {
 
 export function replace_state(this: StreamElement) {
   const url = this.getAttribute("url")
-  const state = this.getAttribute("state")
-  const title = this.getAttribute("title") || ""
+  if (!url) return
 
-  window.history.replaceState(state, title, url)
+  Turbo.navigator.history.replace(new URL(url, document.baseURI))
 }
 
 export function history_back(this: StreamElement) {

--- a/src/actions/history.ts
+++ b/src/actions/history.ts
@@ -33,5 +33,6 @@ export function registerHistoryActions(streamActions: TurboStreamActions) {
   streamActions.push_state = push_state
   streamActions.replace_state = replace_state
   streamActions.history_back = history_back
+  streamActions.history_forward = history_forward
   streamActions.history_go = history_go
 }

--- a/src/actions/history.ts
+++ b/src/actions/history.ts
@@ -1,11 +1,11 @@
+import * as Turbo from "@hotwired/turbo"
 import { StreamElement, TurboStreamActions } from "@hotwired/turbo"
 
 export function push_state(this: StreamElement) {
   const url = this.getAttribute("url")
-  const state = this.getAttribute("state")
-  const title = this.getAttribute("title") || ""
+  if (!url) return
 
-  window.history.pushState(state, title, url)
+  Turbo.navigator.history.push(new URL(url, document.baseURI))
 }
 
 export function replace_state(this: StreamElement) {

--- a/test/history/push_state.test.js
+++ b/test/history/push_state.test.js
@@ -1,4 +1,5 @@
 import sinon from "sinon"
+import * as Turbo from "@hotwired/turbo"
 import { assert } from "@open-wc/testing"
 import { executeStream, registerAction } from "../test_helpers"
 
@@ -9,104 +10,52 @@ describe("push_state", () => {
     sinon.restore()
   })
 
-  context("all attributes", () => {
-    it("should push item to history object", async () => {
-      const fake = sinon.replace(window.history, "pushState", sinon.fake())
+  it("pushes the url onto Turbo's history", async () => {
+    const fake = sinon.replace(Turbo.navigator.history, "push", sinon.fake())
 
-      await executeStream(
-        `<turbo-stream action="push_state" url="${window.location.origin}/new-state" state="state" title="title"></turbo-stream>`,
-      )
+    await executeStream(`<turbo-stream action="push_state" url="${window.location.origin}/new-state"></turbo-stream>`)
 
-      assert.equal(fake.callCount, 1)
-      assert.deepEqual(fake.firstCall.args, ["state", "title", `${window.location.origin}/new-state`])
-    })
+    assert.equal(fake.callCount, 1)
+    assert.instanceOf(fake.firstArg, URL)
+    assert.equal(fake.firstArg.href, `${window.location.origin}/new-state`)
   })
 
-  context("title attribute", () => {
-    it('should push item to history object with missing "title" attribute', async () => {
-      const fake = sinon.replace(window.history, "pushState", sinon.fake())
+  it("resolves a relative url against the document base", async () => {
+    const fake = sinon.replace(Turbo.navigator.history, "push", sinon.fake())
 
-      await executeStream(
-        `<turbo-stream action="push_state" url="${window.location.origin}/new-state" state="state"></turbo-stream>`,
-      )
+    await executeStream(`<turbo-stream action="push_state" url="/relative"></turbo-stream>`)
 
-      assert.equal(fake.callCount, 1)
-      assert.deepEqual(fake.firstCall.args, ["state", "", `${window.location.origin}/new-state`])
-    })
-
-    it('should push item to history object with missing empty "title" attribute', async () => {
-      const fake = sinon.replace(window.history, "pushState", sinon.fake())
-
-      await executeStream(
-        `<turbo-stream action="push_state" url="${window.location.origin}/new-state" state="state" title=""></turbo-stream>`,
-      )
-
-      assert.equal(fake.callCount, 1)
-      assert.deepEqual(fake.firstCall.args, ["state", "", `${window.location.origin}/new-state`])
-    })
+    assert.equal(fake.callCount, 1)
+    assert.instanceOf(fake.firstArg, URL)
+    assert.equal(fake.firstArg.href, `${window.location.origin}/relative`)
   })
 
-  context("state attribute", () => {
-    it('should push item to history object with missing "state" attribute', async () => {
-      const fake = sinon.replace(window.history, "pushState", sinon.fake())
+  it("ignores the legacy state and title attributes", async () => {
+    const fake = sinon.replace(Turbo.navigator.history, "push", sinon.fake())
 
-      await executeStream(
-        `<turbo-stream action="push_state" url="${window.location.origin}/new-state" title="title"></turbo-stream>`,
-      )
+    await executeStream(
+      `<turbo-stream action="push_state" url="${window.location.origin}/x" state="ignored" title="ignored"></turbo-stream>`,
+    )
 
-      assert.equal(fake.callCount, 1)
-      assert.deepEqual(fake.firstCall.args, [null, "title", `${window.location.origin}/new-state`])
-    })
-
-    it('should push item to history object with missing empty "state" attribute', async () => {
-      const fake = sinon.replace(window.history, "pushState", sinon.fake())
-
-      await executeStream(
-        `<turbo-stream action="push_state" url="${window.location.origin}/new-state" state="" title="title"></turbo-stream>`,
-      )
-
-      assert.equal(fake.callCount, 1)
-      assert.deepEqual(fake.firstCall.args, ["", "title", `${window.location.origin}/new-state`])
-    })
+    assert.equal(fake.callCount, 1)
+    assert.instanceOf(fake.firstArg, URL)
+    assert.equal(fake.firstArg.href, `${window.location.origin}/x`)
+    assert.equal(fake.firstCall.args.length, 1)
   })
 
-  context("url attribute", () => {
-    it('should push item to history object with missing "url" attribute', async () => {
-      const fake = sinon.replace(window.history, "pushState", sinon.fake())
+  it("does nothing when url is missing", async () => {
+    const fake = sinon.replace(Turbo.navigator.history, "push", sinon.fake())
 
-      await executeStream('<turbo-stream action="push_state" title="title" state="state"></turbo-stream>')
+    await executeStream(`<turbo-stream action="push_state"></turbo-stream>`)
 
-      assert.equal(fake.callCount, 1)
-      assert.deepEqual(fake.firstCall.args, ["state", "title", null])
-    })
-
-    it('should push item to history object with missing empty "url" attribute', async () => {
-      const fake = sinon.replace(window.history, "pushState", sinon.fake())
-
-      await executeStream('<turbo-stream action="push_state" url="" state="state" title="title"></turbo-stream>')
-
-      assert.equal(fake.callCount, 1)
-      assert.deepEqual(fake.firstCall.args, ["state", "title", ""])
-    })
+    assert.equal(fake.callCount, 0)
   })
 
-  context("no attributes", () => {
-    it("should push item to history object with no attributes", async () => {
-      const fake = sinon.replace(window.history, "pushState", sinon.fake())
+  it("does nothing when url is empty", async () => {
+    const fake = sinon.replace(Turbo.navigator.history, "push", sinon.fake())
 
-      await executeStream('<turbo-stream action="push_state"></turbo-stream>')
+    await executeStream(`<turbo-stream action="push_state" url=""></turbo-stream>`)
 
-      assert.equal(fake.callCount, 1)
-      assert.deepEqual(fake.firstCall.args, [null, "", null])
-    })
-
-    it("should push item to history object with empty attributes", async () => {
-      const fake = sinon.replace(window.history, "pushState", sinon.fake())
-
-      await executeStream('<turbo-stream action="push_state" url="" state="" title=""></turbo-stream>')
-
-      assert.equal(fake.callCount, 1)
-      assert.deepEqual(fake.firstCall.args, ["", "", ""])
-    })
+    assert.equal(fake.callCount, 0)
   })
 })

--- a/test/history/register.test.js
+++ b/test/history/register.test.js
@@ -1,0 +1,15 @@
+import { assert } from "@open-wc/testing"
+import TurboPower from "../../"
+
+describe("registerHistoryActions", () => {
+  it("registers all history actions", () => {
+    const streamActions = {}
+    const actionNames = ["push_state", "replace_state", "history_back", "history_forward", "history_go"]
+
+    TurboPower.Actions.registerHistoryActions(streamActions)
+
+    actionNames.forEach((name) => {
+      assert.typeOf(streamActions[name], "function", `${name} not registered`)
+    })
+  })
+})

--- a/test/history/replace_state.test.js
+++ b/test/history/replace_state.test.js
@@ -1,0 +1,48 @@
+import sinon from "sinon"
+import * as Turbo from "@hotwired/turbo"
+import { assert } from "@open-wc/testing"
+import { executeStream, registerAction } from "../test_helpers"
+
+registerAction("replace_state")
+
+describe("replace_state", () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it("replaces the current entry in Turbo's history", async () => {
+    const fake = sinon.replace(Turbo.navigator.history, "replace", sinon.fake())
+
+    await executeStream(`<turbo-stream action="replace_state" url="${window.location.origin}/replaced"></turbo-stream>`)
+
+    assert.equal(fake.callCount, 1)
+    assert.instanceOf(fake.firstArg, URL)
+    assert.equal(fake.firstArg.href, `${window.location.origin}/replaced`)
+  })
+
+  it("resolves a relative url against the document base", async () => {
+    const fake = sinon.replace(Turbo.navigator.history, "replace", sinon.fake())
+
+    await executeStream(`<turbo-stream action="replace_state" url="/relative"></turbo-stream>`)
+
+    assert.equal(fake.callCount, 1)
+    assert.instanceOf(fake.firstArg, URL)
+    assert.equal(fake.firstArg.href, `${window.location.origin}/relative`)
+  })
+
+  it("does nothing when url is missing", async () => {
+    const fake = sinon.replace(Turbo.navigator.history, "replace", sinon.fake())
+
+    await executeStream(`<turbo-stream action="replace_state"></turbo-stream>`)
+
+    assert.equal(fake.callCount, 0)
+  })
+
+  it("does nothing when url is empty", async () => {
+    const fake = sinon.replace(Turbo.navigator.history, "replace", sinon.fake())
+
+    await executeStream(`<turbo-stream action="replace_state" url=""></turbo-stream>`)
+
+    assert.equal(fake.callCount, 0)
+  })
+})


### PR DESCRIPTION
> **Draft — seeking your call on the breaking change before this is merge-ready.**

Stacks on #337 / #338. Until #338 merges, this PR's diff also shows that PR's single commit (`Register history_forward action`); GitHub will trim it automatically once #338 lands. The substantive commits here are the two action changes plus the README update.

## Problem

`push_state` / `replace_state` drove `window.history` directly. Raw `pushState` / `replaceState` omit the `{ turbo: { restorationIdentifier } }` state key, so Turbo's `popstate` handler ignores the entry and the browser Back button does not behave as expected (#11). The current workaround is the `invoke` action.

## Change

Route both actions through `Turbo.navigator.history.push` / `.replace` (typed, exported API), which set Turbo's state key so restoration works. Relative URLs resolve against `document.baseURI`. Empty/missing `url` is a no-op.

## Breaking change — your call

The `state` and `title` attributes are dropped: Turbo owns its history state (`{ turbo: { restorationIdentifier } }`) and arbitrary state is unsupported. A test locks in that these legacy attributes are now ignored.

I reused the existing action names rather than adding `turbo_*` variants. Happy to switch to new names or a non-breaking fallback (keep raw behavior when `state` is present, Turbo path otherwise) if you'd prefer — flagging before this is merge-ready.

## Notes

- Cross-origin / malformed `url` raises the same `SecurityError` the old code did — not a regression, behaves like a normal Turbo navigation. Not handled here; happy to add a guard if you want one.
- Unit tests stub `Turbo.navigator.history` and assert the right `URL` is passed for both actions (absolute + relative), plus no-op cases. Full suite green (202 tests), lint clean.

Closes #11